### PR TITLE
MB-15 | Feat: Initialize design system with typography and colors 

### DIFF
--- a/packages/theme/src/dark.ts
+++ b/packages/theme/src/dark.ts
@@ -1,7 +1,0 @@
-import { theme } from '@refract-ui/sc';
-
-const dark = theme();
-
-export type RefractTheme = typeof dark;
-
-export default dark;

--- a/packages/theme/src/dark.ts
+++ b/packages/theme/src/dark.ts
@@ -1,0 +1,7 @@
+import { theme } from '@refract-ui/sc';
+
+const dark = theme();
+
+export type RefractTheme = typeof dark;
+
+export default dark;

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -1,39 +1,39 @@
 import { theme } from '@refract-ui/sc';
 
 const defaultTheme = theme({
-    colors: [
-        primary: {
-            yellow: '#FEF600'
-        },
-        neutral: {
-            gray: '#3A3A3A',
-            white: '#FFFFFF',
-            black: '#000000'
-        }
-    ],
-    typography: {
-        h1: {
-            size: 6,
-            lineHeight: 5.689375
-        },
-        h2: {
-            size: 3.75,
-            lineHeight: 3.8125
-        },
-        h3: {
-            size: 2.8125,
-            lineHeight: 3
-        },
-        bodyBold: {
-            size: 1.5,
-            lineHeight: 1.5625,
-            weight: 700
-        },
-        body: {
-            size: 1.5,
-            lineHeight: 1.5625
-        }
+  colors: {
+    primary: {
+      yellow: '#FEF600'
+    },
+    neutral: {
+      gray: '#3A3A3A',
+      white: '#FFFFFF',
+      black: '#000000'
     }
+  },
+  typography: {
+    h1: {
+      size: 6,
+      lineHeight: 5.689375
+    },
+    h2: {
+      size: 3.75,
+      lineHeight: 3.8125
+    },
+    h3: {
+      size: 2.8125,
+      lineHeight: 3
+    },
+    bodyBold: {
+      size: 1.5,
+      lineHeight: 1.5625,
+      weight: 700
+    },
+    body: {
+      size: 1.5,
+      lineHeight: 1.5625
+    }
+  }
 });
 
 export type RefractTheme = typeof defaultTheme;

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -1,16 +1,16 @@
 import { theme } from '@refract-ui/sc';
 
 const defaultTheme = theme({
-  colors: () => ({
+  colors: {
     yellow: '#FEF600',
     gray: '#3A3A3A',
     black: '#000',
     white: '#FFF'
-  }),
+  },
   themeColors: ({ colors }) => ({
     primary: colors.yellow
   }),
-  fontVariants: () => ({
+  fontVariants: {
     heading1: {
       fontSize: '5.75rem',
       lineHeight: 5.689375
@@ -27,7 +27,7 @@ const defaultTheme = theme({
       fontSize: '1.5rem',
       lineHeight: 1.5625
     }
-  })
+  }
 });
 
 export type RefractTheme = typeof defaultTheme;

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -1,39 +1,33 @@
 import { theme } from '@refract-ui/sc';
 
 const defaultTheme = theme({
-  colors: {
-    primary: {
-      yellow: '#FEF600'
-    },
-    neutral: {
-      gray: '#3A3A3A',
-      white: '#FFFFFF',
-      black: '#000000'
-    }
-  },
-  typography: {
-    h1: {
-      size: 6,
+  colors: () => ({
+    yellow: '#FEF600',
+    gray: '#3A3A3A',
+    black: '#000',
+    white: '#FFF'
+  }),
+  themeColors: ({ colors }) => ({
+    primary: colors.yellow
+  }),
+  fontVariants: () => ({
+    heading1: {
+      fontSize: '5.75rem',
       lineHeight: 5.689375
     },
-    h2: {
-      size: 3.75,
-      lineHeight: 3.8125
-    },
-    h3: {
-      size: 2.8125,
+    heading2: {
+      fontSize: '3.75rem',
       lineHeight: 3
     },
-    bodyBold: {
-      size: 1.5,
-      lineHeight: 1.5625,
-      weight: 700
+    heading3: {
+      fontSize: '2.8125rem',
+      lineHeight: 3
     },
     body: {
-      size: 1.5,
+      fontSize: '1.5rem',
       lineHeight: 1.5625
     }
-  }
+  })
 });
 
 export type RefractTheme = typeof defaultTheme;

--- a/packages/theme/src/theme.ts
+++ b/packages/theme/src/theme.ts
@@ -1,6 +1,40 @@
 import { theme } from '@refract-ui/sc';
 
-const defaultTheme = theme();
+const defaultTheme = theme({
+    colors: [
+        primary: {
+            yellow: '#FEF600'
+        },
+        neutral: {
+            gray: '#3A3A3A',
+            white: '#FFFFFF',
+            black: '#000000'
+        }
+    ],
+    typography: {
+        h1: {
+            size: 6,
+            lineHeight: 5.689375
+        },
+        h2: {
+            size: 3.75,
+            lineHeight: 3.8125
+        },
+        h3: {
+            size: 2.8125,
+            lineHeight: 3
+        },
+        bodyBold: {
+            size: 1.5,
+            lineHeight: 1.5625,
+            weight: 700
+        },
+        body: {
+            size: 1.5,
+            lineHeight: 1.5625
+        }
+    }
+});
 
 export type RefractTheme = typeof defaultTheme;
 


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[MB-15](https://graveflex.atlassian.net/browse/MB-15)

<!-- /tickets -->

## Links 
[Figma design system](https://www.figma.com/file/HUtelvVhqFBeL1R8z3MEzF/Myopic-Design?node-id=835%3A167&mode=dev)

<!-- description -->
## Description

This PR establishes a basic color and typography configuration within the theme.ts file. The colors are split into two main categories

Neutrals and non-neutrals. 

Typography matches the Figma with a top level `typography` key.

