### PR TITLE
Feat(component): carousel controls [ECF-48]

### DIFF
--- a/packages/ui/components/CarouselControls/CarouselControls.stories.tsx
+++ b/packages/ui/components/CarouselControls/CarouselControls.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import type { CarouselControlsType } from '.';
+import CarouselControls from '.';
+
+const meta: Meta<CarouselControlsType> = {
+  title: 'ui/CarouselControls',
+  component: CarouselControls,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<CarouselControlsType>;
+
+export const Defaults: Story = {
+  args: {
+    isNextButtonEnabled: true,
+    isPreviousButtonEnabled: false,
+    slideNext: () => {},
+    slidePrevious: () => {}
+  }
+};
+
+export const WithDots: Story = {
+  args: {
+    activeDotIndex: 1,
+    carouselLength: 5,
+    isNextButtonEnabled: true,
+    isPreviousButtonEnabled: false,
+    showDots: true,
+    slideNext: () => {},
+    slidePrevious: () => {}
+  }
+};
+
+export const WithMargin: Story = {
+  args: {
+    activeDotIndex: 1,
+    carouselLength: 5,
+    isNextButtonEnabled: true,
+    isPreviousButtonEnabled: false,
+    showDots: true,
+    hasMargin: true,
+    slideNext: () => {},
+    slidePrevious: () => {}
+  }
+};

--- a/packages/ui/components/CarouselControls/__tests__/index.test.tsx
+++ b/packages/ui/components/CarouselControls/__tests__/index.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { composeStories } from '@storybook/testing-react';
+import { render } from '@testing-library/react';
+
+import projectAnnotations from '@ui/utils/testSetup';
+import * as stories from '../CarouselControls.stories';
+
+const { Defaults } = composeStories(stories, projectAnnotations);
+
+describe('CarouselControls', () => {
+  it('component mounts', () => {
+    render(<Defaults />);
+  });
+});

--- a/packages/ui/components/CarouselControls/index.tsx
+++ b/packages/ui/components/CarouselControls/index.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+const Arrow = styled.button`
+  ${({ theme: { themeColors, mq } }) => css`
+    border: 1px solid ${themeColors.secondary};
+    border-radius: 2.25rem;
+    background-color: transparent;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease-in-out;
+    width: 2rem;
+    height: 2rem;
+    color: ${themeColors.secondary};
+
+    &:disabled {
+      pointer-events: none;
+      opacity: 0.5;
+    }
+
+    &:hover {
+      background-color: ${themeColors.info};
+      border-color: ${themeColors.info};
+      color: ${themeColors.primary};
+      border-radius: 0.5rem;
+    }
+
+    &:focus {
+      outline: 2px solid ${themeColors.info};
+    }
+
+    ${mq.md`
+      width: 3.8125rem;
+      height: 3.8125rem;
+      padding: 0;
+      margin: 0;
+    `}
+  `}
+`;
+
+const ArrowsContainer = styled.div`
+  display: flex;
+  gap: 1.125rem;
+  max-width: 100%;
+  width: 100%;
+`;
+
+type NavContainerProps = {
+  $hasMargin?: boolean;
+};
+
+const NavContainer = styled.div<NavContainerProps>`
+  ${({ theme: { themeColors }, $hasMargin }) => css`
+    display: flex;
+    background-color: ${themeColors.primary};
+    padding: 1.125rem;
+    border-radius: 1.125rem;
+
+    ${$hasMargin &&
+    css`
+      margin: 1.125rem;
+    `}
+  `}
+`;
+
+const PaginationContainer = styled.ul`
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+type DotTypes = {
+  $isActive?: boolean;
+};
+
+const PaginationDot = styled.li<DotTypes>`
+  ${({ $isActive, theme: { themeColors, mq } }) => css`
+    background-color: ${$isActive
+      ? themeColors.secondary
+      : themeColors.primary};
+    border: 1px solid ${themeColors.secondary};
+    border-radius: 0.75rem;
+    flex: 0 0 0.8125rem;
+    list-style-type: none;
+    transition: background 0.15s ease-in-out;
+    height: 0.5rem;
+    min-width: 1.25rem;
+
+    &:not(:last-child) {
+      margin-right: 0.375rem;
+    }
+
+    ${mq.md`
+      height: .5rem;
+      min-width: 2.25rem;
+    `}
+  `}
+`;
+
+export type CarouselControlsType = {
+  activeDotIndex?: number;
+  carouselLength?: number;
+  isNextButtonEnabled?: boolean;
+  isPreviousButtonEnabled?: boolean;
+  showDots?: boolean;
+  hasMargin?: boolean;
+  slideNext?: () => void;
+  slidePrevious?: () => void;
+};
+
+function CarouselControls({
+  activeDotIndex = 0,
+  carouselLength = 0,
+  isNextButtonEnabled = true,
+  isPreviousButtonEnabled = false,
+  showDots = false,
+  hasMargin = false,
+  slideNext,
+  slidePrevious
+}: CarouselControlsType) {
+  return (
+    <NavContainer $hasMargin={hasMargin}>
+      <ArrowsContainer>
+        <Arrow
+          onClick={slidePrevious}
+          disabled={!isPreviousButtonEnabled}
+          tabIndex={0}
+        >
+          {'<'}
+        </Arrow>
+        {showDots && (
+          <PaginationContainer>
+            {[...Array(carouselLength)].map((_, index) => (
+              <PaginationDot
+                key={`slide-'${_}`}
+                $isActive={activeDotIndex === index}
+              />
+            ))}
+          </PaginationContainer>
+        )}
+        <Arrow onClick={slideNext} disabled={!isNextButtonEnabled} tabIndex={0}>
+          {'>'}
+        </Arrow>
+      </ArrowsContainer>
+    </NavContainer>
+  );
+}
+
+export default CarouselControls;

--- a/packages/ui/components/CarouselControls/index.tsx
+++ b/packages/ui/components/CarouselControls/index.tsx
@@ -120,12 +120,14 @@ function CarouselControls({
   isNextButtonEnabled = true,
   isPreviousButtonEnabled = false,
   showDots = false,
+  // ECF Variant - remove in other projects
   hasMargin = false,
   slideNext,
   slidePrevious
 }: CarouselControlsType) {
   return (
     <NavContainer $hasMargin={hasMargin}>
+      {/* CUSTOMIZE: Update Arrow Icons */}
       <ArrowsContainer>
         <Arrow
           onClick={slidePrevious}


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[ECF-48](https://graveflex.atlassian.net/browse/ECF-48)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

Using the [ECF designs](https://www.figma.com/file/a9srXo52ZyhvHHmWRmOtCq/ecf-01-site-v0.2.0?type=design&node-id=3053-14535&mode=design&t=pe4lMvArddFEQiIL-0) as a guide this PR:

- Adds a new component / storybook for the `CarouselControls` component 


(appearance with ECF primary and secondary colors added to the `theme`)
<img width="550" alt="Screenshot 2024-03-26 at 10 39 03 AM" src="https://github.com/graveflex/nextjs-vercel/assets/32271860/da571b96-5a85-4bd6-af6f-0a38630ee279">

Current theme display 

<img width="488" alt="Screenshot 2024-03-26 at 11 01 25 AM" src="https://github.com/graveflex/nextjs-vercel/assets/32271860/abd14d26-8d5f-4a88-8701-4b7fa93ef7ed">

<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
