### PR TITLE
feat(payload): draft preview ECF-96

### DIFF
--- a/apps/web/src/app/(app)/[[...slug]]/page.tsx
+++ b/apps/web/src/app/(app)/[[...slug]]/page.tsx
@@ -14,10 +14,13 @@ interface RootLayoutProps {
   };
   searchParams: {
     draft: string;
-  }
+  };
 }
 
-export default async function Page({ params: { slug }, searchParams }: RootLayoutProps) {
+export default async function Page({
+  params: { slug },
+  searchParams
+}: RootLayoutProps) {
   const pageSlug = slug ? slug.join('/') : '/';
   const showDraft = searchParams.draft === 'true';
   const navData = await fetchPayloadDataRest<Nav>({

--- a/apps/web/src/app/(app)/[[...slug]]/page.tsx
+++ b/apps/web/src/app/(app)/[[...slug]]/page.tsx
@@ -12,16 +12,21 @@ interface RootLayoutProps {
   params: {
     slug: string[];
   };
+  searchParams: {
+    draft: string;
+  }
 }
 
-export default async function Page({ params: { slug } }: RootLayoutProps) {
+export default async function Page({ params: { slug }, searchParams }: RootLayoutProps) {
   const pageSlug = slug ? slug.join('/') : '/';
+  const showDraft = searchParams.draft === 'true';
   const navData = await fetchPayloadDataRest<Nav>({
     endpoint: '/api/payload/globals/nav'
   });
 
   const data = await fetchPayloadDataRest<PaginatedDocs<Page>>({
     endpoint: '/api/payload/pages',
+    showDraft,
     params: {
       where: {
         'pageConfig.slug': {

--- a/apps/web/src/collections/Pages.ts
+++ b/apps/web/src/collections/Pages.ts
@@ -1,8 +1,8 @@
+import { WEB_URL } from '@mono/settings';
 // InsertBlockConfigs
 import FAQBlock from '@mono/web/blocks/FAQBlock/FAQBlock.config';
 import HeroBlock from '@mono/web/blocks/HeroBlock/HeroBlock.config';
 import TextImageBlock from '@mono/web/blocks/TextImageBlock/TextImageBlock.config';
-import { WEB_URL } from '@mono/settings';
 import SEOConfig from '@mono/web/payload/fields/SEO';
 import type { CollectionConfig, GroupField } from 'payload/types';
 
@@ -36,15 +36,16 @@ const PageConfig: GroupField = {
 const Pages: CollectionConfig = {
   slug: 'pages',
   admin: {
-    preview: (doc, {locale, token}) => {
-      const { slug } = doc?.pageConfig as { slug: string } || '/'
+    preview: (doc, { locale }) => {
+      const { slug } = (doc?.pageConfig as { slug: string }) || '/';
 
       if (slug) {
+        // eslint-disable-next-line no-underscore-dangle
         const isDraft = !doc?._status || doc?._status === 'draft';
-        return `${WEB_URL}${slug}?locale=${locale}&draft=${isDraft}`
+        return `${WEB_URL}${slug}?locale=${locale}&draft=${isDraft}`;
       }
-      return null
-    },
+      return null;
+    }
   },
   access: {
     read: () => true

--- a/apps/web/src/collections/Pages.ts
+++ b/apps/web/src/collections/Pages.ts
@@ -2,6 +2,7 @@
 import FAQBlock from '@mono/web/blocks/FAQBlock/FAQBlock.config';
 import HeroBlock from '@mono/web/blocks/HeroBlock/HeroBlock.config';
 import TextImageBlock from '@mono/web/blocks/TextImageBlock/TextImageBlock.config';
+import { WEB_URL } from '@mono/settings';
 import SEOConfig from '@mono/web/payload/fields/SEO';
 import type { CollectionConfig, GroupField } from 'payload/types';
 
@@ -34,6 +35,17 @@ const PageConfig: GroupField = {
 
 const Pages: CollectionConfig = {
   slug: 'pages',
+  admin: {
+    preview: (doc, {locale, token}) => {
+      const { slug } = doc?.pageConfig as { slug: string } || '/'
+
+      if (slug) {
+        const isDraft = !doc?._status || doc?._status === 'draft';
+        return `${WEB_URL}${slug}?locale=${locale}&draft=${isDraft}`
+      }
+      return null
+    },
+  },
   access: {
     read: () => true
   },

--- a/apps/web/src/lib/fetchPayloadDataRest.ts
+++ b/apps/web/src/lib/fetchPayloadDataRest.ts
@@ -5,6 +5,7 @@ import qs from 'qs';
 export type FetchPayloadRequest = {
   endpoint: string;
   params?: object;
+  showDraft?: boolean;
   next?: {
     revalidate?: false | 0 | number;
     tags?: string[];
@@ -19,12 +20,13 @@ export type FetchPayloadResponse<T> = T | { error: string };
 async function fetchPayloadDataRest<T>({
   endpoint,
   params,
+  showDraft,
   next,
   accessToken
 }: FetchPayloadRequest): Promise<FetchPayloadResponse<T>> {
   const url = `${WEB_URL}${endpoint}${qs.stringify(params, {
     addQueryPrefix: true
-  })}`;
+  })}?&draft=${showDraft}`;
 
   try {
     const res = await fetch(url, {

--- a/apps/web/src/lib/fetchPayloadDataRest.ts
+++ b/apps/web/src/lib/fetchPayloadDataRest.ts
@@ -24,9 +24,7 @@ async function fetchPayloadDataRest<T>({
   next,
   accessToken
 }: FetchPayloadRequest): Promise<FetchPayloadResponse<T>> {
-  const url = `${WEB_URL}${endpoint}${qs.stringify(params, {
-    addQueryPrefix: true
-  })}?&draft=${showDraft}`;
+  const url = `${WEB_URL}${endpoint}?${qs.stringify({ ...params, draft: showDraft }, { addQueryPrefix: true })}`;
 
   try {
     const res = await fetch(url, {

--- a/apps/web/src/lib/fetchPayloadDataRest.ts
+++ b/apps/web/src/lib/fetchPayloadDataRest.ts
@@ -24,7 +24,10 @@ async function fetchPayloadDataRest<T>({
   next,
   accessToken
 }: FetchPayloadRequest): Promise<FetchPayloadResponse<T>> {
-  const url = `${WEB_URL}${endpoint}?${qs.stringify({ ...params, draft: showDraft }, { addQueryPrefix: true })}`;
+  const url = `${WEB_URL}${endpoint}?${qs.stringify(
+    { ...params, draft: showDraft },
+    { addQueryPrefix: true }
+  )}`;
 
   try {
     const res = await fetch(url, {

--- a/apps/web/src/lib/fetchPayloadDataRest.ts
+++ b/apps/web/src/lib/fetchPayloadDataRest.ts
@@ -24,7 +24,7 @@ async function fetchPayloadDataRest<T>({
   next,
   accessToken
 }: FetchPayloadRequest): Promise<FetchPayloadResponse<T>> {
-  const url = `${WEB_URL}${endpoint}?${qs.stringify(
+  const url = `${WEB_URL}${endpoint}${qs.stringify(
     { ...params, draft: showDraft },
     { addQueryPrefix: true }
   )}`;


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[ECF-96](https://graveflex.atlassian.net/browse/ECF-96)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

This PR: 

1. Updates the admin props for the Page collection to use `preview` --> this automatically renders the "preview" button on any CMS edit page. 
<img width="498" alt="Screenshot 2024-04-01 at 1 17 19 PM" src="https://github.com/graveflex/nextjs-vercel/assets/32271860/e609627a-839f-4b44-92f6-e86f29672d72">

2. Updates the Payload fetch req to include the draft status param in the `url`, this allows drafted blocks to render if the `draft=true` is present in the url. 

<!-- reproduction -->
## Reproduction Steps

TO TEST: 

1. go to the PR deploy [admin](https://nextjs-vercel-monorepo-eoyqbq3b5-graveflex.vercel.app/admin)
2. Log in e: `admin@graveflex.com` p: `secret123` 
3. Go to the exisiting page and make some edits ---> select `SAVE DRAFT` 
4. Click the `preview` button 
5. This will open a new tab where you will the see the drafted changes 
6. Verify that the deployed [site](https://nextjs-vercel-monorepo-eoyqbq3b5-graveflex.vercel.app) does not show these changes

<!-- checks -->
<!-- /checks -->
