### PR TITLE
hotFix(icons): storybook defaults 

### DIFF
--- a/packages/ui/components/RenderIcon/RenderIcon.stories.tsx
+++ b/packages/ui/components/RenderIcon/RenderIcon.stories.tsx
@@ -16,7 +16,9 @@ export default meta;
 type Story = StoryObj<IconProps>;
 
 export const Defaults: Story = {
-  args: {}
+  args: {
+    name: 'Quote'
+  }
 };
 
 export const ArrowNesting: Story = {

--- a/packages/ui/components/RenderIcon/index.tsx
+++ b/packages/ui/components/RenderIcon/index.tsx
@@ -12,7 +12,12 @@ export type IconProps = {
   width?: string | null;
 };
 
-function CoreIcons({ name = 'Quote', color, height, width }: IconProps) {
+function CoreIcons({
+  name = 'Quote',
+  color,
+  height = '25',
+  width = '25'
+}: IconProps) {
   const Icon = !isNull(name) && coreIcons?.[name];
   if (Icon) {
     return (


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[ECF-50](https://graveflex.atlassian.net/browse/ECF-50)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

During dev QA of the icon component, RenderIcon's storybook entry was not populating, this PR adds in `width` and `height` defaults so only the Icon name is required. 

<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
