### PR TITLE
feat(remove): pageConfig ref

### DIFF
--- a/apps/web/src/hooks/publishBeforeRead.ts
+++ b/apps/web/src/hooks/publishBeforeRead.ts
@@ -22,7 +22,7 @@ export const publishBeforeRead: BeforeReadHook = async ({ doc, req }) => {
     where: {
       and: [
         {
-          'version.pageConfig.slug': { equals: doc.pageConfig.slug },
+          'version.slug': { equals: doc.slug },
           'version._status': { equals: 'published' }
         },
         {


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[TICKET NUMBER](LINK TO TICKET)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

Since the new block config fields remove the `pageConfig` group. `slug` is now at the top level and was sending a console error. 

<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
