### PR TITLE
feat(add): simplify button styles + variants

### DIFF
--- a/apps/web/bin/seed-nav.ts
+++ b/apps/web/bin/seed-nav.ts
@@ -90,7 +90,7 @@ const cta = {
       label: 'Get a Demo',
       externalHref: '/demo'
     },
-    variant: 'rounded-outline' as variantEnum
+    variant: 'solid' as variantEnum
   }
 };
 

--- a/apps/web/bin/seed-nav.ts
+++ b/apps/web/bin/seed-nav.ts
@@ -207,7 +207,7 @@ const seedNavUsingPayload = async ({ payload }: SeedFnProps) => {
               { type: 'paragraph', text: 'Welcome to our Demo Repo' }
             ])
           },
-          background: 'black'
+          background: 'gray'
         }
       },
       footer: {

--- a/apps/web/src/migrations/20240614_164258.json
+++ b/apps/web/src/migrations/20240614_164258.json
@@ -1,0 +1,5725 @@
+{
+  "id": "cfb74e06-d215-45b0-b11d-3418558f0478",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "pages_blocks_card_grid_block_cards_card_ctas": {
+      "name": "pages_blocks_card_grid_block_cards_card_ctas",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cta_link_type": {
+          "name": "cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_label": {
+          "name": "cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_external_href": {
+          "name": "cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_email_href": {
+          "name": "cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_phone_href": {
+          "name": "cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_new_tab": {
+          "name": "cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_name": {
+          "name": "cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_size": {
+          "name": "cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_color": {
+          "name": "cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_variant": {
+          "name": "cta_variant",
+          "type": "card_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_card_grid_block_cards_card_ctas_order_idx": {
+          "name": "pages_blocks_card_grid_block_cards_card_ctas_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_card_grid_block_cards_card_ctas_parent_id_idx": {
+          "name": "pages_blocks_card_grid_block_cards_card_ctas_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_card_grid_block_cards_card_ctas_parent_id_fk": {
+          "name": "pages_blocks_card_grid_block_cards_card_ctas_parent_id_fk",
+          "tableFrom": "pages_blocks_card_grid_block_cards_card_ctas",
+          "tableTo": "pages_blocks_card_grid_block_cards",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_card_grid_block_cards": {
+      "name": "pages_blocks_card_grid_block_cards",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_eyebrow": {
+          "name": "card_eyebrow",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_headline": {
+          "name": "card_headline",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_sub_head": {
+          "name": "card_sub_head",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_card_grid_block_cards_order_idx": {
+          "name": "pages_blocks_card_grid_block_cards_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_card_grid_block_cards_parent_id_idx": {
+          "name": "pages_blocks_card_grid_block_cards_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_card_grid_block_cards_locale_idx": {
+          "name": "pages_blocks_card_grid_block_cards_locale_idx",
+          "columns": [
+            "_locale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_card_grid_block_cards_parent_id_fk": {
+          "name": "pages_blocks_card_grid_block_cards_parent_id_fk",
+          "tableFrom": "pages_blocks_card_grid_block_cards",
+          "tableTo": "pages_blocks_card_grid_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_card_grid_block": {
+      "name": "pages_blocks_card_grid_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum_pages_blocks_card_grid_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_card_grid_block_order_idx": {
+          "name": "pages_blocks_card_grid_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_card_grid_block_parent_id_idx": {
+          "name": "pages_blocks_card_grid_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_card_grid_block_path_idx": {
+          "name": "pages_blocks_card_grid_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_card_grid_block_parent_id_fk": {
+          "name": "pages_blocks_card_grid_block_parent_id_fk",
+          "tableFrom": "pages_blocks_card_grid_block",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_card_grid_block_locales": {
+      "name": "pages_blocks_card_grid_block_locales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_blocks_card_grid_block_locales_parent_id_fk": {
+          "name": "pages_blocks_card_grid_block_locales_parent_id_fk",
+          "tableFrom": "pages_blocks_card_grid_block_locales",
+          "tableTo": "pages_blocks_card_grid_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pages_blocks_card_grid_block_locales_locale_parent_id_unique": {
+          "name": "pages_blocks_card_grid_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "pages_blocks_markdown_block": {
+      "name": "pages_blocks_markdown_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum_pages_blocks_markdown_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_markdown_block_order_idx": {
+          "name": "pages_blocks_markdown_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_markdown_block_parent_id_idx": {
+          "name": "pages_blocks_markdown_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_markdown_block_path_idx": {
+          "name": "pages_blocks_markdown_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_markdown_block_parent_id_fk": {
+          "name": "pages_blocks_markdown_block_parent_id_fk",
+          "tableFrom": "pages_blocks_markdown_block",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_markdown_block_locales": {
+      "name": "pages_blocks_markdown_block_locales",
+      "schema": "",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxWidth": {
+          "name": "maxWidth",
+          "type": "enum_pages_blocks_markdown_block_max_width",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_blocks_markdown_block_locales_parent_id_fk": {
+          "name": "pages_blocks_markdown_block_locales_parent_id_fk",
+          "tableFrom": "pages_blocks_markdown_block_locales",
+          "tableTo": "pages_blocks_markdown_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pages_blocks_markdown_block_locales_locale_parent_id_unique": {
+          "name": "pages_blocks_markdown_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "pages_blocks_faq_block_items": {
+      "name": "pages_blocks_faq_block_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pages_blocks_faq_block_items_order_idx": {
+          "name": "pages_blocks_faq_block_items_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_faq_block_items_parent_id_idx": {
+          "name": "pages_blocks_faq_block_items_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_faq_block_items_parent_id_fk": {
+          "name": "pages_blocks_faq_block_items_parent_id_fk",
+          "tableFrom": "pages_blocks_faq_block_items",
+          "tableTo": "pages_blocks_faq_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_faq_block_items_locales": {
+      "name": "pages_blocks_faq_block_items_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_title": {
+          "name": "sub_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_blocks_faq_block_items_locales_parent_id_fk": {
+          "name": "pages_blocks_faq_block_items_locales_parent_id_fk",
+          "tableFrom": "pages_blocks_faq_block_items_locales",
+          "tableTo": "pages_blocks_faq_block_items",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pages_blocks_faq_block_items_locales_locale_parent_id_unique": {
+          "name": "pages_blocks_faq_block_items_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "pages_blocks_faq_block": {
+      "name": "pages_blocks_faq_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum_pages_blocks_faq_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_faq_block_order_idx": {
+          "name": "pages_blocks_faq_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_faq_block_parent_id_idx": {
+          "name": "pages_blocks_faq_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_faq_block_path_idx": {
+          "name": "pages_blocks_faq_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_faq_block_parent_id_fk": {
+          "name": "pages_blocks_faq_block_parent_id_fk",
+          "tableFrom": "pages_blocks_faq_block",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_faq_block_locales": {
+      "name": "pages_blocks_faq_block_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_title": {
+          "name": "sub_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_blocks_faq_block_locales_parent_id_fk": {
+          "name": "pages_blocks_faq_block_locales_parent_id_fk",
+          "tableFrom": "pages_blocks_faq_block_locales",
+          "tableTo": "pages_blocks_faq_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pages_blocks_faq_block_locales_locale_parent_id_unique": {
+          "name": "pages_blocks_faq_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "pages_blocks_text_image_block": {
+      "name": "pages_blocks_text_image_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum_pages_blocks_text_image_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_layout": {
+          "name": "blockConfig_layout",
+          "type": "enum_pages_blocks_text_image_block_block_config_layout",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_type": {
+          "name": "cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_label": {
+          "name": "cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_external_href": {
+          "name": "cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_email_href": {
+          "name": "cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_phone_href": {
+          "name": "cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_new_tab": {
+          "name": "cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_name": {
+          "name": "cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_size": {
+          "name": "cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_color": {
+          "name": "cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_variant": {
+          "name": "cta_variant",
+          "type": "undefined_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_text_image_block_order_idx": {
+          "name": "pages_blocks_text_image_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_text_image_block_parent_id_idx": {
+          "name": "pages_blocks_text_image_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_text_image_block_path_idx": {
+          "name": "pages_blocks_text_image_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_text_image_block_parent_id_fk": {
+          "name": "pages_blocks_text_image_block_parent_id_fk",
+          "tableFrom": "pages_blocks_text_image_block",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_text_image_block_locales": {
+      "name": "pages_blocks_text_image_block_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_blocks_text_image_block_locales_parent_id_fk": {
+          "name": "pages_blocks_text_image_block_locales_parent_id_fk",
+          "tableFrom": "pages_blocks_text_image_block_locales",
+          "tableTo": "pages_blocks_text_image_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pages_blocks_text_image_block_locales_locale_parent_id_unique": {
+          "name": "pages_blocks_text_image_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "pages_blocks_hero_block": {
+      "name": "pages_blocks_hero_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum_pages_blocks_hero_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_layout": {
+          "name": "blockConfig_layout",
+          "type": "enum_pages_blocks_hero_block_block_config_layout",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_type": {
+          "name": "input_type",
+          "type": "enum_pages_blocks_hero_block_input_type",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_type": {
+          "name": "cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_label": {
+          "name": "cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_external_href": {
+          "name": "cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_email_href": {
+          "name": "cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_phone_href": {
+          "name": "cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_new_tab": {
+          "name": "cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_name": {
+          "name": "cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_size": {
+          "name": "cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_color": {
+          "name": "cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_variant": {
+          "name": "cta_variant",
+          "type": "undefined_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_blocks_hero_block_order_idx": {
+          "name": "pages_blocks_hero_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_hero_block_parent_id_idx": {
+          "name": "pages_blocks_hero_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_blocks_hero_block_path_idx": {
+          "name": "pages_blocks_hero_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_blocks_hero_block_parent_id_fk": {
+          "name": "pages_blocks_hero_block_parent_id_fk",
+          "tableFrom": "pages_blocks_hero_block",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_blocks_hero_block_locales": {
+      "name": "pages_blocks_hero_block_locales",
+      "schema": "",
+      "columns": {
+        "eyebrow": {
+          "name": "eyebrow",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_title": {
+          "name": "sub_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pages_blocks_hero_block_locales_parent_id_fk": {
+          "name": "pages_blocks_hero_block_locales_parent_id_fk",
+          "tableFrom": "pages_blocks_hero_block_locales",
+          "tableTo": "pages_blocks_hero_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pages_blocks_hero_block_locales_locale_parent_id_unique": {
+          "name": "pages_blocks_hero_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "page_title": {
+          "name": "page_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "enum_pages_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_config_title": {
+          "name": "seo_config_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_config_description": {
+          "name": "seo_config_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seo_config_keywords": {
+          "name": "seo_config_keywords",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "_status": {
+          "name": "_status",
+          "type": "enum_pages_status",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_created_at_idx": {
+          "name": "pages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pages_rels": {
+      "name": "pages_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images_id": {
+          "name": "images_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_id": {
+          "name": "files_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_rels_order_idx": {
+          "name": "pages_rels_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "pages_rels_parent_idx": {
+          "name": "pages_rels_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "pages_rels_path_idx": {
+          "name": "pages_rels_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_rels_parent_fk": {
+          "name": "pages_rels_parent_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_images_fk": {
+          "name": "pages_rels_images_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "images",
+          "columnsFrom": [
+            "images_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_pages_fk": {
+          "name": "pages_rels_pages_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pages_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pages_rels_files_fk": {
+          "name": "pages_rels_files_fk",
+          "tableFrom": "pages_rels",
+          "tableTo": "files",
+          "columnsFrom": [
+            "files_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_card_grid_block_cards_card_ctas": {
+      "name": "_pages_v_blocks_card_grid_block_cards_card_ctas",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cta_link_type": {
+          "name": "cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_label": {
+          "name": "cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_external_href": {
+          "name": "cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_email_href": {
+          "name": "cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_phone_href": {
+          "name": "cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_new_tab": {
+          "name": "cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_name": {
+          "name": "cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_size": {
+          "name": "cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_color": {
+          "name": "cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_variant": {
+          "name": "cta_variant",
+          "type": "card_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_card_grid_block_cards_card_ctas_order_idx": {
+          "name": "_pages_v_blocks_card_grid_block_cards_card_ctas_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_card_grid_block_cards_card_ctas_parent_id_idx": {
+          "name": "_pages_v_blocks_card_grid_block_cards_card_ctas_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_card_grid_block_cards_card_ctas_parent_id_fk": {
+          "name": "_pages_v_blocks_card_grid_block_cards_card_ctas_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_card_grid_block_cards_card_ctas",
+          "tableTo": "_pages_v_blocks_card_grid_block_cards",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_card_grid_block_cards": {
+      "name": "_pages_v_blocks_card_grid_block_cards",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "card_eyebrow": {
+          "name": "card_eyebrow",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_headline": {
+          "name": "card_headline",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_sub_head": {
+          "name": "card_sub_head",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_card_grid_block_cards_order_idx": {
+          "name": "_pages_v_blocks_card_grid_block_cards_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_card_grid_block_cards_parent_id_idx": {
+          "name": "_pages_v_blocks_card_grid_block_cards_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_card_grid_block_cards_locale_idx": {
+          "name": "_pages_v_blocks_card_grid_block_cards_locale_idx",
+          "columns": [
+            "_locale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_card_grid_block_cards_parent_id_fk": {
+          "name": "_pages_v_blocks_card_grid_block_cards_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_card_grid_block_cards",
+          "tableTo": "_pages_v_blocks_card_grid_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_card_grid_block": {
+      "name": "_pages_v_blocks_card_grid_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum__pages_v_blocks_card_grid_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_card_grid_block_order_idx": {
+          "name": "_pages_v_blocks_card_grid_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_card_grid_block_parent_id_idx": {
+          "name": "_pages_v_blocks_card_grid_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_card_grid_block_path_idx": {
+          "name": "_pages_v_blocks_card_grid_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_card_grid_block_parent_id_fk": {
+          "name": "_pages_v_blocks_card_grid_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_card_grid_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_card_grid_block_locales": {
+      "name": "_pages_v_blocks_card_grid_block_locales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_pages_v_blocks_card_grid_block_locales_parent_id_fk": {
+          "name": "_pages_v_blocks_card_grid_block_locales_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_card_grid_block_locales",
+          "tableTo": "_pages_v_blocks_card_grid_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "_pages_v_blocks_card_grid_block_locales_locale_parent_id_unique": {
+          "name": "_pages_v_blocks_card_grid_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "_pages_v_blocks_markdown_block": {
+      "name": "_pages_v_blocks_markdown_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum__pages_v_blocks_markdown_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_markdown_block_order_idx": {
+          "name": "_pages_v_blocks_markdown_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_markdown_block_parent_id_idx": {
+          "name": "_pages_v_blocks_markdown_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_markdown_block_path_idx": {
+          "name": "_pages_v_blocks_markdown_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_markdown_block_parent_id_fk": {
+          "name": "_pages_v_blocks_markdown_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_markdown_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_markdown_block_locales": {
+      "name": "_pages_v_blocks_markdown_block_locales",
+      "schema": "",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxWidth": {
+          "name": "maxWidth",
+          "type": "enum__pages_v_blocks_markdown_block_max_width",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_pages_v_blocks_markdown_block_locales_parent_id_fk": {
+          "name": "_pages_v_blocks_markdown_block_locales_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_markdown_block_locales",
+          "tableTo": "_pages_v_blocks_markdown_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "_pages_v_blocks_markdown_block_locales_locale_parent_id_unique": {
+          "name": "_pages_v_blocks_markdown_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "_pages_v_blocks_faq_block_items": {
+      "name": "_pages_v_blocks_faq_block_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_faq_block_items_order_idx": {
+          "name": "_pages_v_blocks_faq_block_items_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_faq_block_items_parent_id_idx": {
+          "name": "_pages_v_blocks_faq_block_items_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_faq_block_items_parent_id_fk": {
+          "name": "_pages_v_blocks_faq_block_items_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_faq_block_items",
+          "tableTo": "_pages_v_blocks_faq_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_faq_block_items_locales": {
+      "name": "_pages_v_blocks_faq_block_items_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_title": {
+          "name": "sub_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_pages_v_blocks_faq_block_items_locales_parent_id_fk": {
+          "name": "_pages_v_blocks_faq_block_items_locales_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_faq_block_items_locales",
+          "tableTo": "_pages_v_blocks_faq_block_items",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "_pages_v_blocks_faq_block_items_locales_locale_parent_id_unique": {
+          "name": "_pages_v_blocks_faq_block_items_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "_pages_v_blocks_faq_block": {
+      "name": "_pages_v_blocks_faq_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum__pages_v_blocks_faq_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_faq_block_order_idx": {
+          "name": "_pages_v_blocks_faq_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_faq_block_parent_id_idx": {
+          "name": "_pages_v_blocks_faq_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_faq_block_path_idx": {
+          "name": "_pages_v_blocks_faq_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_faq_block_parent_id_fk": {
+          "name": "_pages_v_blocks_faq_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_faq_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_faq_block_locales": {
+      "name": "_pages_v_blocks_faq_block_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_title": {
+          "name": "sub_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_pages_v_blocks_faq_block_locales_parent_id_fk": {
+          "name": "_pages_v_blocks_faq_block_locales_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_faq_block_locales",
+          "tableTo": "_pages_v_blocks_faq_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "_pages_v_blocks_faq_block_locales_locale_parent_id_unique": {
+          "name": "_pages_v_blocks_faq_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "_pages_v_blocks_text_image_block": {
+      "name": "_pages_v_blocks_text_image_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum__pages_v_blocks_text_image_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_layout": {
+          "name": "blockConfig_layout",
+          "type": "enum__pages_v_blocks_text_image_block_block_config_layout",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_type": {
+          "name": "cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_label": {
+          "name": "cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_external_href": {
+          "name": "cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_email_href": {
+          "name": "cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_phone_href": {
+          "name": "cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_new_tab": {
+          "name": "cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_name": {
+          "name": "cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_size": {
+          "name": "cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_color": {
+          "name": "cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_variant": {
+          "name": "cta_variant",
+          "type": "undefined_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_text_image_block_order_idx": {
+          "name": "_pages_v_blocks_text_image_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_text_image_block_parent_id_idx": {
+          "name": "_pages_v_blocks_text_image_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_text_image_block_path_idx": {
+          "name": "_pages_v_blocks_text_image_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_text_image_block_parent_id_fk": {
+          "name": "_pages_v_blocks_text_image_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_text_image_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_text_image_block_locales": {
+      "name": "_pages_v_blocks_text_image_block_locales",
+      "schema": "",
+      "columns": {
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_pages_v_blocks_text_image_block_locales_parent_id_fk": {
+          "name": "_pages_v_blocks_text_image_block_locales_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_text_image_block_locales",
+          "tableTo": "_pages_v_blocks_text_image_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "_pages_v_blocks_text_image_block_locales_locale_parent_id_unique": {
+          "name": "_pages_v_blocks_text_image_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "_pages_v_blocks_hero_block": {
+      "name": "_pages_v_blocks_hero_block",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_path": {
+          "name": "_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockConfig_theme": {
+          "name": "blockConfig_theme",
+          "type": "enum__pages_v_blocks_hero_block_block_config_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_backgroundColor": {
+          "name": "blockConfig_backgroundColor",
+          "type": "bgColor",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_config_hidden": {
+          "name": "block_config_hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_contentWidth": {
+          "name": "blockConfig_contentWidth",
+          "type": "cw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingTop": {
+          "name": "blockConfig_p_xs_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xs_paddingBottom": {
+          "name": "blockConfig_p_xs_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingTop": {
+          "name": "blockConfig_p_md_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_md_paddingBottom": {
+          "name": "blockConfig_p_md_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingTop": {
+          "name": "blockConfig_p_lg_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_lg_paddingBottom": {
+          "name": "blockConfig_p_lg_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingTop": {
+          "name": "blockConfig_p_xl_paddingTop",
+          "type": "t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_p_xl_paddingBottom": {
+          "name": "blockConfig_p_xl_paddingBottom",
+          "type": "b",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockConfig_layout": {
+          "name": "blockConfig_layout",
+          "type": "enum__pages_v_blocks_hero_block_block_config_layout",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_placeholder": {
+          "name": "input_placeholder",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_type": {
+          "name": "input_type",
+          "type": "enum__pages_v_blocks_hero_block_input_type",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_type": {
+          "name": "cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_label": {
+          "name": "cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_external_href": {
+          "name": "cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_email_href": {
+          "name": "cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_phone_href": {
+          "name": "cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_new_tab": {
+          "name": "cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_name": {
+          "name": "cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_size": {
+          "name": "cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_link_icon_color": {
+          "name": "cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_variant": {
+          "name": "cta_variant",
+          "type": "undefined_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "_uuid": {
+          "name": "_uuid",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_name": {
+          "name": "block_name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_blocks_hero_block_order_idx": {
+          "name": "_pages_v_blocks_hero_block_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_hero_block_parent_id_idx": {
+          "name": "_pages_v_blocks_hero_block_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_blocks_hero_block_path_idx": {
+          "name": "_pages_v_blocks_hero_block_path_idx",
+          "columns": [
+            "_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_blocks_hero_block_parent_id_fk": {
+          "name": "_pages_v_blocks_hero_block_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_hero_block",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_blocks_hero_block_locales": {
+      "name": "_pages_v_blocks_hero_block_locales",
+      "schema": "",
+      "columns": {
+        "eyebrow": {
+          "name": "eyebrow",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_title": {
+          "name": "sub_title",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "_pages_v_blocks_hero_block_locales_parent_id_fk": {
+          "name": "_pages_v_blocks_hero_block_locales_parent_id_fk",
+          "tableFrom": "_pages_v_blocks_hero_block_locales",
+          "tableTo": "_pages_v_blocks_hero_block",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "_pages_v_blocks_hero_block_locales_locale_parent_id_unique": {
+          "name": "_pages_v_blocks_hero_block_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "_pages_v": {
+      "name": "_pages_v",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_page_title": {
+          "name": "version_page_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_slug": {
+          "name": "version_slug",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_theme": {
+          "name": "version_theme",
+          "type": "enum__pages_v_version_theme",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_seo_config_title": {
+          "name": "version_seo_config_title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_seo_config_description": {
+          "name": "version_seo_config_description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_seo_config_keywords": {
+          "name": "version_seo_config_keywords",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_published_at": {
+          "name": "version_published_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_updated_at": {
+          "name": "version_updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_created_at": {
+          "name": "version_created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version__status": {
+          "name": "version__status",
+          "type": "enum__pages_v_version_status",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "latest": {
+          "name": "latest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_version_version_created_at_idx": {
+          "name": "_pages_v_version_version_created_at_idx",
+          "columns": [
+            "version_created_at"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_created_at_idx": {
+          "name": "_pages_v_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_updated_at_idx": {
+          "name": "_pages_v_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_latest_idx": {
+          "name": "_pages_v_latest_idx",
+          "columns": [
+            "latest"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "_pages_v_rels": {
+      "name": "_pages_v_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images_id": {
+          "name": "images_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_id": {
+          "name": "files_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "_pages_v_rels_order_idx": {
+          "name": "_pages_v_rels_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_rels_parent_idx": {
+          "name": "_pages_v_rels_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "_pages_v_rels_path_idx": {
+          "name": "_pages_v_rels_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "_pages_v_rels_parent_fk": {
+          "name": "_pages_v_rels_parent_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "_pages_v",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_pages_fk": {
+          "name": "_pages_v_rels_pages_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pages_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_images_fk": {
+          "name": "_pages_v_rels_images_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "images",
+          "columnsFrom": [
+            "images_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "_pages_v_rels_files_fk": {
+          "name": "_pages_v_rels_files_fk",
+          "tableFrom": "_pages_v_rels",
+          "tableTo": "files",
+          "columnsFrom": [
+            "files_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reset_password_token": {
+          "name": "reset_password_token",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_password_expiration": {
+          "name": "reset_password_expiration",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "salt": {
+          "name": "salt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "login_attempts": {
+          "name": "login_attempts",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_until": {
+          "name": "lock_until",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "users_email_idx": {
+          "name": "users_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_created_at_idx": {
+          "name": "files_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "files_filename_idx": {
+          "name": "files_filename_idx",
+          "columns": [
+            "filename"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_props_fill": {
+          "name": "image_props_fill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_props_priority": {
+          "name": "image_props_priority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_props_quality": {
+          "name": "image_props_quality",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additionalProps_objectFit": {
+          "name": "additionalProps_objectFit",
+          "type": "enum_images_additional_props_object_fit",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_props_is_rounded": {
+          "name": "additional_props_is_rounded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additionalProps_aspectRatio": {
+          "name": "additionalProps_aspectRatio",
+          "type": "enum_images_additional_props_aspect_ratio",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_url": {
+          "name": "sizes_thumbnail_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_width": {
+          "name": "sizes_thumbnail_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_height": {
+          "name": "sizes_thumbnail_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_mime_type": {
+          "name": "sizes_thumbnail_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_filesize": {
+          "name": "sizes_thumbnail_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_thumbnail_filename": {
+          "name": "sizes_thumbnail_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_mobile_url": {
+          "name": "sizes_mobile_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_mobile_width": {
+          "name": "sizes_mobile_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_mobile_height": {
+          "name": "sizes_mobile_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_mobile_mime_type": {
+          "name": "sizes_mobile_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_mobile_filesize": {
+          "name": "sizes_mobile_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_mobile_filename": {
+          "name": "sizes_mobile_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_tablet_url": {
+          "name": "sizes_tablet_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_tablet_width": {
+          "name": "sizes_tablet_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_tablet_height": {
+          "name": "sizes_tablet_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_tablet_mime_type": {
+          "name": "sizes_tablet_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_tablet_filesize": {
+          "name": "sizes_tablet_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_tablet_filename": {
+          "name": "sizes_tablet_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_desktop_url": {
+          "name": "sizes_desktop_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_desktop_width": {
+          "name": "sizes_desktop_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_desktop_height": {
+          "name": "sizes_desktop_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_desktop_mime_type": {
+          "name": "sizes_desktop_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_desktop_filesize": {
+          "name": "sizes_desktop_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_desktop_filename": {
+          "name": "sizes_desktop_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_ultrawide_url": {
+          "name": "sizes_ultrawide_url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_ultrawide_width": {
+          "name": "sizes_ultrawide_width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_ultrawide_height": {
+          "name": "sizes_ultrawide_height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_ultrawide_mime_type": {
+          "name": "sizes_ultrawide_mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_ultrawide_filesize": {
+          "name": "sizes_ultrawide_filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizes_ultrawide_filename": {
+          "name": "sizes_ultrawide_filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "images_created_at_idx": {
+          "name": "images_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "images_filename_idx": {
+          "name": "images_filename_idx",
+          "columns": [
+            "filename"
+          ],
+          "isUnique": true
+        },
+        "images_sizes_thumbnail_sizes_thumbnail_filename_idx": {
+          "name": "images_sizes_thumbnail_sizes_thumbnail_filename_idx",
+          "columns": [
+            "sizes_thumbnail_filename"
+          ],
+          "isUnique": false
+        },
+        "images_sizes_mobile_sizes_mobile_filename_idx": {
+          "name": "images_sizes_mobile_sizes_mobile_filename_idx",
+          "columns": [
+            "sizes_mobile_filename"
+          ],
+          "isUnique": false
+        },
+        "images_sizes_tablet_sizes_tablet_filename_idx": {
+          "name": "images_sizes_tablet_sizes_tablet_filename_idx",
+          "columns": [
+            "sizes_tablet_filename"
+          ],
+          "isUnique": false
+        },
+        "images_sizes_desktop_sizes_desktop_filename_idx": {
+          "name": "images_sizes_desktop_sizes_desktop_filename_idx",
+          "columns": [
+            "sizes_desktop_filename"
+          ],
+          "isUnique": false
+        },
+        "images_sizes_ultrawide_sizes_ultrawide_filename_idx": {
+          "name": "images_sizes_ultrawide_sizes_ultrawide_filename_idx",
+          "columns": [
+            "sizes_ultrawide_filename"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "images_locales": {
+      "name": "images_locales",
+      "schema": "",
+      "columns": {
+        "alt": {
+          "name": "alt",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "images_locales_parent_id_fk": {
+          "name": "images_locales_parent_id_fk",
+          "tableFrom": "images_locales",
+          "tableTo": "images",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "images_locales_locale_parent_id_unique": {
+          "name": "images_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "videos": {
+      "name": "videos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_u_r_l": {
+          "name": "thumbnail_u_r_l",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filesize": {
+          "name": "filesize",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_x": {
+          "name": "focal_x",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "focal_y": {
+          "name": "focal_y",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "videos_created_at_idx": {
+          "name": "videos_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "videos_filename_idx": {
+          "name": "videos_filename_idx",
+          "columns": [
+            "filename"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "payload_preferences": {
+      "name": "payload_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_preferences_key_idx": {
+          "name": "payload_preferences_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": false
+        },
+        "payload_preferences_created_at_idx": {
+          "name": "payload_preferences_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "payload_preferences_rels": {
+      "name": "payload_preferences_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "users_id": {
+          "name": "users_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "payload_preferences_rels_order_idx": {
+          "name": "payload_preferences_rels_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "payload_preferences_rels_parent_idx": {
+          "name": "payload_preferences_rels_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "payload_preferences_rels_path_idx": {
+          "name": "payload_preferences_rels_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "payload_preferences_rels_parent_fk": {
+          "name": "payload_preferences_rels_parent_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "payload_preferences",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payload_preferences_rels_users_fk": {
+          "name": "payload_preferences_rels_users_fk",
+          "tableFrom": "payload_preferences_rels",
+          "tableTo": "users",
+          "columnsFrom": [
+            "users_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "payload_migrations": {
+      "name": "payload_migrations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batch": {
+          "name": "batch",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payload_migrations_created_at_idx": {
+          "name": "payload_migrations_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav_header_collapsible_menu_sections_links": {
+      "name": "nav_header_collapsible_menu_sections_links",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_external_href": {
+          "name": "link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_email_href": {
+          "name": "link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_phone_href": {
+          "name": "link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_name": {
+          "name": "link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_size": {
+          "name": "link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_color": {
+          "name": "link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nav_header_collapsible_menu_sections_links_order_idx": {
+          "name": "nav_header_collapsible_menu_sections_links_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "nav_header_collapsible_menu_sections_links_parent_id_idx": {
+          "name": "nav_header_collapsible_menu_sections_links_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nav_header_collapsible_menu_sections_links_parent_id_fk": {
+          "name": "nav_header_collapsible_menu_sections_links_parent_id_fk",
+          "tableFrom": "nav_header_collapsible_menu_sections_links",
+          "tableTo": "nav_header_collapsible_menu_sections",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav_header_collapsible_menu_sections": {
+      "name": "nav_header_collapsible_menu_sections",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "nav_header_collapsible_menu_sections_order_idx": {
+          "name": "nav_header_collapsible_menu_sections_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "nav_header_collapsible_menu_sections_parent_id_idx": {
+          "name": "nav_header_collapsible_menu_sections_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        },
+        "nav_header_collapsible_menu_sections_locale_idx": {
+          "name": "nav_header_collapsible_menu_sections_locale_idx",
+          "columns": [
+            "_locale"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nav_header_collapsible_menu_sections_parent_id_fk": {
+          "name": "nav_header_collapsible_menu_sections_parent_id_fk",
+          "tableFrom": "nav_header_collapsible_menu_sections",
+          "tableTo": "nav",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav_header_flat_menu": {
+      "name": "nav_header_flat_menu",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_external_href": {
+          "name": "link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_email_href": {
+          "name": "link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_phone_href": {
+          "name": "link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_name": {
+          "name": "link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_size": {
+          "name": "link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_color": {
+          "name": "link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nav_header_flat_menu_order_idx": {
+          "name": "nav_header_flat_menu_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "nav_header_flat_menu_parent_id_idx": {
+          "name": "nav_header_flat_menu_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nav_header_flat_menu_parent_id_fk": {
+          "name": "nav_header_flat_menu_parent_id_fk",
+          "tableFrom": "nav_header_flat_menu",
+          "tableTo": "nav",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav_header_icon_items": {
+      "name": "nav_header_icon_items",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "href": {
+          "name": "href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_tab": {
+          "name": "new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_name": {
+          "name": "icon_name",
+          "type": "iconnavitem_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_size": {
+          "name": "icon_size",
+          "type": "iconnavitem_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_color": {
+          "name": "icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nav_header_icon_items_order_idx": {
+          "name": "nav_header_icon_items_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "nav_header_icon_items_parent_id_idx": {
+          "name": "nav_header_icon_items_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nav_header_icon_items_parent_id_fk": {
+          "name": "nav_header_icon_items_parent_id_fk",
+          "tableFrom": "nav_header_icon_items",
+          "tableTo": "nav",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav_footer_footer_items_footer_menu": {
+      "name": "nav_footer_footer_items_footer_menu",
+      "schema": "",
+      "columns": {
+        "_order": {
+          "name": "_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_label": {
+          "name": "link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_external_href": {
+          "name": "link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_email_href": {
+          "name": "link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_phone_href": {
+          "name": "link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_new_tab": {
+          "name": "link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_name": {
+          "name": "link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_size": {
+          "name": "link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_icon_color": {
+          "name": "link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nav_footer_footer_items_footer_menu_order_idx": {
+          "name": "nav_footer_footer_items_footer_menu_order_idx",
+          "columns": [
+            "_order"
+          ],
+          "isUnique": false
+        },
+        "nav_footer_footer_items_footer_menu_parent_id_idx": {
+          "name": "nav_footer_footer_items_footer_menu_parent_id_idx",
+          "columns": [
+            "_parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nav_footer_footer_items_footer_menu_parent_id_fk": {
+          "name": "nav_footer_footer_items_footer_menu_parent_id_fk",
+          "tableFrom": "nav_footer_footer_items_footer_menu",
+          "tableTo": "nav",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav": {
+      "name": "nav",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "header_banner_content": {
+          "name": "header_banner_content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_banner_background": {
+          "name": "header_banner_background",
+          "type": "enum_nav_header_banner_background",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_has_cta": {
+          "name": "header_has_cta",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_ctaButton_cta_link_type": {
+          "name": "header_ctaButton_cta_link_type",
+          "type": "undefined_cta_t",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_cta_button_cta_link_label": {
+          "name": "header_cta_button_cta_link_label",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_cta_button_cta_link_external_href": {
+          "name": "header_cta_button_cta_link_external_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_cta_button_cta_link_email_href": {
+          "name": "header_cta_button_cta_link_email_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_cta_button_cta_link_phone_href": {
+          "name": "header_cta_button_cta_link_phone_href",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_cta_button_cta_link_new_tab": {
+          "name": "header_cta_button_cta_link_new_tab",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_ctaButton_cta_link_icon_name": {
+          "name": "header_ctaButton_cta_link_icon_name",
+          "type": "undefined_link_ic",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_ctaButton_cta_link_icon_size": {
+          "name": "header_ctaButton_cta_link_icon_size",
+          "type": "undefined_link_iw",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_cta_button_cta_link_icon_color": {
+          "name": "header_cta_button_cta_link_icon_color",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "header_ctaButton_cta_variant": {
+          "name": "header_ctaButton_cta_variant",
+          "type": "undefined_cta_v",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footer_footer_items_copyright": {
+          "name": "footer_footer_items_copyright",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "footer_footer_items_legal_disclaimer": {
+          "name": "footer_footer_items_legal_disclaimer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "nav_locales": {
+      "name": "nav_locales",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "nav_locales_parent_id_fk": {
+          "name": "nav_locales_parent_id_fk",
+          "tableFrom": "nav_locales",
+          "tableTo": "nav",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "nav_locales_locale_parent_id_unique": {
+          "name": "nav_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    },
+    "nav_rels": {
+      "name": "nav_rels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images_id": {
+          "name": "images_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pages_id": {
+          "name": "pages_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "files_id": {
+          "name": "files_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nav_rels_order_idx": {
+          "name": "nav_rels_order_idx",
+          "columns": [
+            "order"
+          ],
+          "isUnique": false
+        },
+        "nav_rels_parent_idx": {
+          "name": "nav_rels_parent_idx",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "nav_rels_path_idx": {
+          "name": "nav_rels_path_idx",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "nav_rels_parent_fk": {
+          "name": "nav_rels_parent_fk",
+          "tableFrom": "nav_rels",
+          "tableTo": "nav",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nav_rels_images_fk": {
+          "name": "nav_rels_images_fk",
+          "tableFrom": "nav_rels",
+          "tableTo": "images",
+          "columnsFrom": [
+            "images_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nav_rels_pages_fk": {
+          "name": "nav_rels_pages_fk",
+          "tableFrom": "nav_rels",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pages_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "nav_rels_files_fk": {
+          "name": "nav_rels_files_fk",
+          "tableFrom": "nav_rels",
+          "tableTo": "files",
+          "columnsFrom": [
+            "files_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "four_oh_four": {
+      "name": "four_oh_four",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp(3) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "four_oh_four_locales": {
+      "name": "four_oh_four_locales",
+      "schema": "",
+      "columns": {
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "_locale": {
+          "name": "_locale",
+          "type": "_locales",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "_parent_id": {
+          "name": "_parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "four_oh_four_locales_parent_id_fk": {
+          "name": "four_oh_four_locales_parent_id_fk",
+          "tableFrom": "four_oh_four_locales",
+          "tableTo": "four_oh_four",
+          "columnsFrom": [
+            "_parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "four_oh_four_locales_locale_parent_id_unique": {
+          "name": "four_oh_four_locales_locale_parent_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "_locale",
+            "_parent_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "_locales": {
+      "name": "_locales",
+      "values": {
+        "en-US": "en-US",
+        "es-US": "es-US"
+      }
+    },
+    "enum_pages_theme": {
+      "name": "enum_pages_theme",
+      "values": {
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum_pages_blocks_card_grid_block_block_config_theme": {
+      "name": "enum_pages_blocks_card_grid_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "bgColor": {
+      "name": "bgColor",
+      "values": {
+        "fg": "fg",
+        "neutral": "neutral",
+        "blue": "blue",
+        "indigo": "indigo",
+        "purple": "purple"
+      }
+    },
+    "cw": {
+      "name": "cw",
+      "values": {
+        "full": "full",
+        "xxl": "xxl",
+        "xl": "xl",
+        "lg": "lg",
+        "md": "md",
+        "sm": "sm",
+        "xs": "xs"
+      }
+    },
+    "t": {
+      "name": "t",
+      "values": {
+        "9.375rem": "9.375rem",
+        "7.5rem": "7.5rem",
+        "3.75rem": "3.75rem",
+        "2.25rem": "2.25rem",
+        "1.125rem": "1.125rem",
+        "unset": "unset"
+      }
+    },
+    "b": {
+      "name": "b",
+      "values": {
+        "9.375rem": "9.375rem",
+        "7.5rem": "7.5rem",
+        "3.75rem": "3.75rem",
+        "2.25rem": "2.25rem",
+        "1.125rem": "1.125rem",
+        "unset": "unset"
+      }
+    },
+    "undefined_cta_t": {
+      "name": "undefined_cta_t",
+      "values": {
+        "internal": "internal",
+        "external": "external",
+        "email": "email",
+        "phone": "phone",
+        "file": "file"
+      }
+    },
+    "undefined_link_ic": {
+      "name": "undefined_link_ic",
+      "values": {
+        "Hamburger": "Hamburger",
+        "Check": "Check",
+        "ArrowUp": "ArrowUp",
+        "ArrowLeft": "ArrowLeft",
+        "ArrowRight": "ArrowRight",
+        "ArrowDown": "ArrowDown",
+        "CaretDown": "CaretDown",
+        "CaretUp": "CaretUp",
+        "CaretRight": "CaretRight",
+        "CaretLeft": "CaretLeft",
+        "Close": "Close",
+        "DoubleCaretDown": "DoubleCaretDown",
+        "DoubleCaretUp": "DoubleCaretUp",
+        "DoubleCaretRight": "DoubleCaretRight",
+        "DoubleCaretLeft": "DoubleCaretLeft",
+        "Error": "Error",
+        "LinkOut": "LinkOut",
+        "MinusSign": "MinusSign",
+        "Person": "Person",
+        "PlusSign": "PlusSign",
+        "Quote": "Quote",
+        "Search": "Search",
+        "SolidArrowDown": "SolidArrowDown",
+        "SolidArrowUp": "SolidArrowUp",
+        "SolidArrowRight": "SolidArrowRight",
+        "SolidArrowLeft": "SolidArrowLeft",
+        "ArrowNesting": "ArrowNesting"
+      }
+    },
+    "undefined_link_iw": {
+      "name": "undefined_link_iw",
+      "values": {
+        "20": "20",
+        "25": "25",
+        "30": "30",
+        "35": "35"
+      }
+    },
+    "card_cta_v": {
+      "name": "card_cta_v",
+      "values": {
+        "outline": "outline",
+        "solid": "solid",
+        "link": "link"
+      }
+    },
+    "enum_pages_blocks_markdown_block_block_config_theme": {
+      "name": "enum_pages_blocks_markdown_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum_pages_blocks_markdown_block_max_width": {
+      "name": "enum_pages_blocks_markdown_block_max_width",
+      "values": {
+        "1440px": "1440px",
+        "1280px": "1280px",
+        "992px": "992px",
+        "768px": "768px",
+        "576px": "576px",
+        "320px": "320px",
+        "unset": "unset"
+      }
+    },
+    "enum_pages_blocks_faq_block_block_config_theme": {
+      "name": "enum_pages_blocks_faq_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum_pages_blocks_text_image_block_block_config_theme": {
+      "name": "enum_pages_blocks_text_image_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum_pages_blocks_text_image_block_block_config_layout": {
+      "name": "enum_pages_blocks_text_image_block_block_config_layout",
+      "values": {
+        "imgRight": "imgRight",
+        "imgLeft": "imgLeft"
+      }
+    },
+    "undefined_cta_v": {
+      "name": "undefined_cta_v",
+      "values": {
+        "outline": "outline",
+        "solid": "solid",
+        "link": "link"
+      }
+    },
+    "enum_pages_blocks_hero_block_block_config_theme": {
+      "name": "enum_pages_blocks_hero_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum_pages_blocks_hero_block_block_config_layout": {
+      "name": "enum_pages_blocks_hero_block_block_config_layout",
+      "values": {
+        "bg": "bg",
+        "imgRight": "imgRight",
+        "imgLeft": "imgLeft",
+        "imgRightFull": "imgRightFull",
+        "imgLeftFull": "imgLeftFull"
+      }
+    },
+    "enum_pages_blocks_hero_block_input_type": {
+      "name": "enum_pages_blocks_hero_block_input_type",
+      "values": {
+        "text": "text"
+      }
+    },
+    "enum_pages_status": {
+      "name": "enum_pages_status",
+      "values": {
+        "draft": "draft",
+        "published": "published"
+      }
+    },
+    "enum__pages_v_version_theme": {
+      "name": "enum__pages_v_version_theme",
+      "values": {
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum__pages_v_blocks_card_grid_block_block_config_theme": {
+      "name": "enum__pages_v_blocks_card_grid_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum__pages_v_blocks_markdown_block_block_config_theme": {
+      "name": "enum__pages_v_blocks_markdown_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum__pages_v_blocks_markdown_block_max_width": {
+      "name": "enum__pages_v_blocks_markdown_block_max_width",
+      "values": {
+        "1440px": "1440px",
+        "1280px": "1280px",
+        "992px": "992px",
+        "768px": "768px",
+        "576px": "576px",
+        "320px": "320px",
+        "unset": "unset"
+      }
+    },
+    "enum__pages_v_blocks_faq_block_block_config_theme": {
+      "name": "enum__pages_v_blocks_faq_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum__pages_v_blocks_text_image_block_block_config_theme": {
+      "name": "enum__pages_v_blocks_text_image_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum__pages_v_blocks_text_image_block_block_config_layout": {
+      "name": "enum__pages_v_blocks_text_image_block_block_config_layout",
+      "values": {
+        "imgRight": "imgRight",
+        "imgLeft": "imgLeft"
+      }
+    },
+    "enum__pages_v_blocks_hero_block_block_config_theme": {
+      "name": "enum__pages_v_blocks_hero_block_block_config_theme",
+      "values": {
+        "_": "_",
+        "light": "light",
+        "dark": "dark"
+      }
+    },
+    "enum__pages_v_blocks_hero_block_block_config_layout": {
+      "name": "enum__pages_v_blocks_hero_block_block_config_layout",
+      "values": {
+        "bg": "bg",
+        "imgRight": "imgRight",
+        "imgLeft": "imgLeft",
+        "imgRightFull": "imgRightFull",
+        "imgLeftFull": "imgLeftFull"
+      }
+    },
+    "enum__pages_v_blocks_hero_block_input_type": {
+      "name": "enum__pages_v_blocks_hero_block_input_type",
+      "values": {
+        "text": "text"
+      }
+    },
+    "enum__pages_v_version_status": {
+      "name": "enum__pages_v_version_status",
+      "values": {
+        "draft": "draft",
+        "published": "published"
+      }
+    },
+    "enum_images_additional_props_object_fit": {
+      "name": "enum_images_additional_props_object_fit",
+      "values": {
+        "cover": "cover",
+        "contain": "contain",
+        "fill": "fill",
+        "scale-down": "scale-down"
+      }
+    },
+    "enum_images_additional_props_aspect_ratio": {
+      "name": "enum_images_additional_props_aspect_ratio",
+      "values": {
+        "1/1": "1/1",
+        "3/2": "3/2",
+        "4/3": "4/3",
+        "6/7": "6/7",
+        "16/9": "16/9",
+        "initial": "initial"
+      }
+    },
+    "enum_nav_header_banner_background": {
+      "name": "enum_nav_header_banner_background",
+      "values": {
+        "white": "white",
+        "black": "black",
+        "gray": "gray"
+      }
+    },
+    "iconnavitem_ic": {
+      "name": "iconnavitem_ic",
+      "values": {
+        "Hamburger": "Hamburger",
+        "Check": "Check",
+        "ArrowUp": "ArrowUp",
+        "ArrowLeft": "ArrowLeft",
+        "ArrowRight": "ArrowRight",
+        "ArrowDown": "ArrowDown",
+        "CaretDown": "CaretDown",
+        "CaretUp": "CaretUp",
+        "CaretRight": "CaretRight",
+        "CaretLeft": "CaretLeft",
+        "Close": "Close",
+        "DoubleCaretDown": "DoubleCaretDown",
+        "DoubleCaretUp": "DoubleCaretUp",
+        "DoubleCaretRight": "DoubleCaretRight",
+        "DoubleCaretLeft": "DoubleCaretLeft",
+        "Error": "Error",
+        "LinkOut": "LinkOut",
+        "MinusSign": "MinusSign",
+        "Person": "Person",
+        "PlusSign": "PlusSign",
+        "Quote": "Quote",
+        "Search": "Search",
+        "SolidArrowDown": "SolidArrowDown",
+        "SolidArrowUp": "SolidArrowUp",
+        "SolidArrowRight": "SolidArrowRight",
+        "SolidArrowLeft": "SolidArrowLeft",
+        "ArrowNesting": "ArrowNesting"
+      }
+    },
+    "iconnavitem_iw": {
+      "name": "iconnavitem_iw",
+      "values": {
+        "20": "20",
+        "25": "25",
+        "30": "30",
+        "35": "35"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/apps/web/src/migrations/20240614_164258.ts
+++ b/apps/web/src/migrations/20240614_164258.ts
@@ -1,0 +1,29 @@
+import { MigrateUpArgs, MigrateDownArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ payload }: MigrateUpArgs): Promise<void> {
+await payload.db.drizzle.execute(sql`
+
+ALTER TYPE "card_cta_v" ADD VALUE 'outline';
+ALTER TYPE "card_cta_v" ADD VALUE 'solid';
+ALTER TYPE "undefined_cta_v" ADD VALUE 'outline';
+ALTER TYPE "undefined_cta_v" ADD VALUE 'solid';`);
+
+};
+
+export async function down({ payload }: MigrateDownArgs): Promise<void> {
+await payload.db.drizzle.execute(sql`
+
+ALTER TYPE "undefined_link_ic" ADD VALUE 'Login';
+ALTER TYPE "undefined_link_ic" ADD VALUE 'Menu';
+ALTER TYPE "undefined_link_ic" ADD VALUE 'Location';
+ALTER TYPE "undefined_link_ic" ADD VALUE 'Calendar';
+ALTER TYPE "undefined_link_ic" ADD VALUE 'PersonBust';
+ALTER TYPE "card_cta_v" ADD VALUE 'rounded-outline';
+ALTER TYPE "undefined_cta_v" ADD VALUE 'rounded-outline';
+ALTER TYPE "iconnavitem_ic" ADD VALUE 'Login';
+ALTER TYPE "iconnavitem_ic" ADD VALUE 'Menu';
+ALTER TYPE "iconnavitem_ic" ADD VALUE 'Location';
+ALTER TYPE "iconnavitem_ic" ADD VALUE 'Calendar';
+ALTER TYPE "iconnavitem_ic" ADD VALUE 'PersonBust';`);
+
+};

--- a/apps/web/src/payload/fields/CTA.ts
+++ b/apps/web/src/payload/fields/CTA.ts
@@ -29,12 +29,16 @@ function CTA({
             name: 'variant',
             label: 'Variant',
             type: 'select',
-            defaultValue: defaultVariant || 'rounded-outline',
+            defaultValue: defaultVariant || 'solid',
             dbName: `${name?.toLowerCase()}_cta_v`,
             options: [
               {
-                label: 'Rounded Outline',
-                value: 'rounded-outline'
+                label: 'Outline',
+                value: 'outline'
+              },
+              {
+                label: 'Solid',
+                value: 'solid'
               },
               {
                 label: 'Link',

--- a/packages/theme/src/colors.ts
+++ b/packages/theme/src/colors.ts
@@ -1,0 +1,18 @@
+export default {
+  black: '#000000',
+  white: '#FFFFFF',
+  green: '#1AB96D',
+  red: '#FD0505',
+  orange: '#F0AD00',
+  darkOrange: '#F5692D',
+  pink: '#FCBDA2',
+  teal: '#D1DBFF',
+  blue: '#3066F3',
+  lightBlue: '#D1DBFF',
+  neutral: '#7A7A7A',
+  yellow: '#F4F91D',
+  lightYellow: '#FEFCC3',
+  limeGreen: '#BCF560',
+  lightGreen: '#D8F1AE',
+  offWhite: '#E9E9E9'
+};

--- a/packages/theme/src/dark.ts
+++ b/packages/theme/src/dark.ts
@@ -2,6 +2,7 @@
 
 import { theme } from '@refract-ui/sc';
 
+import colors from './colors';
 import fontStacks from './fontStacks';
 import textVariants from './typography';
 
@@ -10,5 +11,25 @@ export default theme({
   textVariants,
   luminance: {
     range: [1.0, 0.9, 0.8, 0.1]
+  },
+  themeColors: {
+    primary: colors.limeGreen,
+    primaryLight: colors.lightGreen,
+    secondary: colors.darkOrange,
+    secondaryLight: colors.pink,
+    info: colors.blue,
+    warning: colors.orange,
+    danger: colors.red,
+    success: colors.green,
+    dark: colors.black,
+    light: colors.white
+  },
+  colorTokens: {
+    bg: ({ themeColors }) => themeColors.dark,
+    fg: ({ themeColors }) => themeColors.light,
+    color1: ({ themeColors }) => themeColors.dark,
+    color2: ({ themeColors }) => themeColors.light,
+    color3: colors.neutral,
+    color4: colors.offWhite
   }
 });

--- a/packages/theme/src/light.ts
+++ b/packages/theme/src/light.ts
@@ -2,6 +2,7 @@
 
 import { theme } from '@refract-ui/sc';
 
+import colors from './colors';
 import fontStacks from './fontStacks';
 import textVariants from './typography';
 
@@ -10,5 +11,26 @@ export default theme({
   textVariants,
   luminance: {
     range: [1.0, 0.9, 0.8, 0.1]
+  },
+  themeColors: {
+    primary: colors.blue,
+    primaryLight: colors.lightBlue,
+    secondary: colors.yellow,
+    secondaryLight: colors.lightYellow,
+    info: colors.blue,
+    warning: colors.orange,
+    danger: colors.red,
+    success: colors.green,
+    plain: colors.black,
+    dark: colors.black,
+    light: colors.white
+  },
+  colorTokens: {
+    bg: ({ themeColors }) => themeColors.dark,
+    fg: ({ themeColors }) => themeColors.light,
+    color1: ({ themeColors }) => themeColors.dark,
+    color2: ({ themeColors }) => themeColors.light,
+    color3: colors.neutral,
+    color4: colors.offWhite
   }
 });

--- a/packages/types/payload-types.ts
+++ b/packages/types/payload-types.ts
@@ -214,7 +214,7 @@ export interface Image {
  */
 export interface CTAType {
   link?: PayLoadLink;
-  variant?: ('rounded-outline' | 'link') | null;
+  variant?: ('outline' | 'solid' | 'link') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/packages/ui/components/Button/Button.stories.tsx
+++ b/packages/ui/components/Button/Button.stories.tsx
@@ -18,8 +18,73 @@ type Story = StoryObj<ButtonProps>;
 export const Defaults: Story = {
   args: {
     children: 'Call to Action',
+    $variant: 'solid',
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const Outline: Story = {
+  args: {
+    children: 'Call to Action',
+    $variant: 'outline',
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const Link: Story = {
+  args: {
+    children: 'Call to Action',
+    $variant: 'link',
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const SolidIcon: Story = {
+  args: {
+    children: 'Call to Action',
+    $variant: 'solid',
     icon: { name: 'ArrowRight', color: 'currentColor' },
-    $variant: 'rounded-outline',
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const OutlineIcon: Story = {
+  args: {
+    children: 'Call to Action',
+    $variant: 'outline',
+    icon: { name: 'ArrowRight', color: 'currentColor' },
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const LinkIcon: Story = {
+  args: {
+    children: 'Call to Action',
+    $variant: 'link',
+    icon: { name: 'ArrowRight', color: 'currentColor' },
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const SolidIconOnly: Story = {
+  args: {
+    $variant: 'solid',
+    icon: { name: 'ArrowRight', color: 'currentColor' },
+    $color: 'secondary',
+    type: 'button'
+  }
+};
+
+export const OutlineIconOnly: Story = {
+  args: {
+    $variant: 'outline',
+    icon: { name: 'ArrowRight', color: 'currentColor' },
     $color: 'secondary',
     type: 'button'
   }

--- a/packages/ui/components/Button/index.tsx
+++ b/packages/ui/components/Button/index.tsx
@@ -53,8 +53,10 @@ const getVariantStyles = (
         ${box.t('button')};
 
         &:hover {
-          color: ${allColors.fg};
-          border-color: ${allColors.fg};
+          color: ${allColors.bg};
+          border-color: ${allColors[color]};
+          background-color: ${allColors[color]};
+          opacity: 0.9;
         }
       `}
     `;
@@ -65,10 +67,14 @@ const getVariantStyles = (
       ${box.t('button')};
       background-color: ${allColors[color]};
       border-radius: 1rem;
+      border: 1px solid transparent;
+      color: ${allColors.bg};
 
       &:hover {
         opacity: 0.9;
-        outline: 1px solid ${allColors.fg};
+        background-color: transparent;
+        color: ${allColors[color]};
+        border: 1px solid ${allColors[color]};
       }
 
       &:disabled {
@@ -95,6 +101,7 @@ const constructButtonStyles = () => {
       align-items: center;
       justify-content: center;
       cursor: pointer;
+      text-decoration: none;
       svg path {
         fill: currentColor;
       }
@@ -112,6 +119,14 @@ const constructButtonStyles = () => {
 
 const StyledButton = styled.button<ButtonProps>`
   ${constructButtonStyles()}
+  a {
+    color: inherit;
+    text-decoration: none;
+    &:hover {
+      box-shadow: none;
+      color: inherit;
+    }
+  }
 
   &:hover {
     box-shadow: none;
@@ -152,7 +167,7 @@ function Button({ element = 'span', icon, children, ...props }: ButtonProps) {
 
   /* styles & Invalid html attributes */
   const styleProps = {
-    $color: props?.$color ?? 'secondary',
+    $color: props?.$color ?? 'primary',
     $variant: props?.$variant ?? 'solid'
     // $invert: props?.$invert ?? false
   };

--- a/packages/ui/components/Button/index.tsx
+++ b/packages/ui/components/Button/index.tsx
@@ -9,9 +9,9 @@ type colorProps = keyof DefaultTheme['allColors'];
 type colorTokenProps = keyof DefaultTheme['colorTokens'];
 
 export type ButtonProps = {
-  $variant?: 'rounded-outline' | 'link';
+  $variant?: 'solid' | 'outline' | 'link';
   $color: colorProps | colorTokenProps;
-  $invert?: boolean;
+  // $invert?: boolean; enable this for theme inversion for button text color
   icon?: IconProps;
   children?: React.ReactNode | string | number;
   element?: 'button' | 'span';
@@ -22,21 +22,8 @@ export type ButtonProps = {
 
 const getVariantStyles = (
   variant: ButtonProps['$variant'],
-  color: ButtonProps['$color'],
-  invert: ButtonProps['$invert']
+  color: ButtonProps['$color']
 ): ReturnType<typeof css> => {
-  const hoverLight = css`
-    ${({ theme: { allColors } }) => css`
-      ${invert ? allColors.bg : allColors.fg}
-    `}
-  `;
-
-  const hoverDark = css`
-    ${({ theme: { allColors } }) => css`
-      ${invert ? allColors.fg : allColors.bg}
-    `}
-  `;
-
   if (variant === 'link') {
     return css`
       ${({ theme: { allColors, box } }) => css`
@@ -45,13 +32,29 @@ const getVariantStyles = (
         border: 1px solid transparent;
         border-bottom-color: ${allColors[color]};
         border-radius: 0;
+        padding: 0;
         ${box.t('button')};
 
         &:hover {
-          color: ${hoverDark};
-          background-color: transparent;
-          /* box shadow to avoid content shifting */
-          box-shadow: inset 0 -3px 0 ${hoverDark};
+          color: ${allColors.fg};
+          border-bottom-color: ${allColors.fg};
+        }
+      `}
+    `;
+  }
+
+  if (variant === 'outline') {
+    return css`
+      ${({ theme: { allColors, box } }) => css`
+        color: ${allColors[color]};
+        background-color: transparent;
+        border: 1px solid ${allColors[color]};
+        border-radius: 1rem;
+        ${box.t('button')};
+
+        &:hover {
+          color: ${allColors.fg};
+          border-color: ${allColors.fg};
         }
       `}
     `;
@@ -59,52 +62,13 @@ const getVariantStyles = (
 
   return css`
     ${({ theme: { allColors, box } }) => css`
-      color: ${allColors[color]};
       ${box.t('button')};
-      background-color: transparent;
-      border: 1px solid currentColor;
-      border-radius: 36px;
-      transition:
-        background-color 0.2s ease,
-        color 0.2s ease,
-        border-radius 0.2s ease,
-        border-color 0.2s ease;
-
-      &[type='reset'] {
-        background-color: transparent;
-        color: ${allColors.danger};
-
-        &:hover {
-          color: white;
-        }
-      }
-
-      &[type='submit'] {
-        background-color: transparent;
-        border-color: ${allColors[color]};
-
-        .button-text {
-          color: ${allColors[color]};
-        }
-
-        &:hover {
-          background-color: ${hoverDark};
-
-          svg {
-            fill: white;
-          }
-
-          .button-text {
-            color: ${hoverLight};
-          }
-        }
-      }
+      background-color: ${allColors[color]};
+      border-radius: 1rem;
 
       &:hover {
-        border-radius: 6px;
-        border-color: transparent;
-        background-color: ${hoverDark};
-        color: ${hoverLight};
+        opacity: 0.9;
+        outline: 1px solid ${allColors.fg};
       }
 
       &:disabled {
@@ -114,7 +78,7 @@ const getVariantStyles = (
         /* revert any hover / focus styles when disabled */
         background-color: transparent;
         border: 1px solid ${allColors[color]};
-        border-radius: 36px;
+        border-radius: 1rem;
       }
     `}
   `;
@@ -122,16 +86,14 @@ const getVariantStyles = (
 
 const constructButtonStyles = () => {
   return css<ButtonProps>`
-    ${({ $color, $variant, $invert }) => css`
+    ${({ $color, $variant }) => css`
       display: inline-flex;
-      padding: 0 1.125rem;
-      min-height: 3.8125rem;
-      min-width: 3.8125rem;
+      padding: 0.62rem 1rem 0.75rem;
+      min-height: 2.625rem;
       width: fit-content;
       column-gap: 0.75rem;
       align-items: center;
       justify-content: center;
-      text-transform: capitalize;
       cursor: pointer;
       svg path {
         fill: currentColor;
@@ -143,7 +105,7 @@ const constructButtonStyles = () => {
         top: 1px;
       }
 
-      ${getVariantStyles($variant, $color, $invert)}
+      ${getVariantStyles($variant, $color)}
     `}
   `;
 };
@@ -172,6 +134,13 @@ const StyleSpan = styled.span<ButtonProps>`
   }
 `;
 
+const InnerWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+`;
+
 function Button({ element = 'span', icon, children, ...props }: ButtonProps) {
   /* Props specific to button element & valid html attributes */
   const buttonProps = {
@@ -184,8 +153,8 @@ function Button({ element = 'span', icon, children, ...props }: ButtonProps) {
   /* styles & Invalid html attributes */
   const styleProps = {
     $color: props?.$color ?? 'secondary',
-    $variant: props?.$variant ?? 'rounded-outline',
-    $invert: props?.$invert ?? false
+    $variant: props?.$variant ?? 'solid'
+    // $invert: props?.$invert ?? false
   };
   const buttonClass = `button-${styleProps.$variant}`;
 
@@ -197,15 +166,21 @@ function Button({ element = 'span', icon, children, ...props }: ButtonProps) {
         {...styleProps}
         className={buttonClass}
       >
-        {children ? <span className="button-text">{children}</span> : null}
-        {icon && RenderIcon(icon)}
+        {children ? (
+          <InnerWrapper className="button-text">
+            {children} {icon && RenderIcon(icon)}
+          </InnerWrapper>
+        ) : null}
       </StyledButton>
     );
   }
   return (
     <StyleSpan {...styleProps} className={buttonClass}>
-      {children && <span className="button-text">{children}</span>}
-      {icon && RenderIcon(icon)}
+      {children && (
+        <InnerWrapper className="button-text">
+          {children} {icon && RenderIcon(icon)}
+        </InnerWrapper>
+      )}
     </StyleSpan>
   );
 }

--- a/packages/ui/components/CtaButton/index.tsx
+++ b/packages/ui/components/CtaButton/index.tsx
@@ -31,7 +31,7 @@ function CtaButton({ cta, color, linkType = 'button' }: CtaButtonType) {
           $variant={cta?.variant || 'link'}
           icon={icon}
         >
-          {cta?.link?.label || 'Call to Action'}
+          {cta?.link?.label ?? cta?.link?.label}
         </Button>
       </PayloadLink>
     );
@@ -43,7 +43,7 @@ function CtaButton({ cta, color, linkType = 'button' }: CtaButtonType) {
         href={link ? (ctaEvalHref(link) as string) : ''}
         newTab={cta?.link?.newTab as boolean}
       >
-        {cta?.link?.label || 'Call to Action'}
+        {cta?.link?.label ?? cta?.link?.label}
       </PayloadLink>
     );
   }
@@ -51,7 +51,7 @@ function CtaButton({ cta, color, linkType = 'button' }: CtaButtonType) {
   return (
     <Button
       $color={color || 'secondary'}
-      $variant={cta?.variant || 'rounded-outline'}
+      $variant={cta?.variant || 'solid'}
       icon={icon}
     >
       <a
@@ -59,7 +59,7 @@ function CtaButton({ cta, color, linkType = 'button' }: CtaButtonType) {
         target={cta?.link?.newTab ? '_blank' : ''}
         rel="noreferrer"
       >
-        {cta?.link?.label || 'Call to Action'}
+        {cta?.link?.label ? cta?.link?.label : undefined}
       </a>
     </Button>
   );

--- a/packages/ui/components/CtaButton/index.tsx
+++ b/packages/ui/components/CtaButton/index.tsx
@@ -27,7 +27,7 @@ function CtaButton({ cta, color, linkType = 'button' }: CtaButtonType) {
         newTab={cta?.link?.newTab as boolean}
       >
         <Button
-          $color={color || 'secondary'}
+          $color={color || 'primary'}
           $variant={cta?.variant || 'link'}
           icon={icon}
         >
@@ -50,9 +50,10 @@ function CtaButton({ cta, color, linkType = 'button' }: CtaButtonType) {
 
   return (
     <Button
-      $color={color || 'secondary'}
+      $color={color || 'primary'}
       $variant={cta?.variant || 'solid'}
       icon={icon}
+      element="button"
     >
       <a
         href={link ? (ctaEvalHref(link) as string) : ''}

--- a/packages/ui/components/CtaLink/index.tsx
+++ b/packages/ui/components/CtaLink/index.tsx
@@ -11,8 +11,8 @@ const LinkStyled = styled(Link)`
   text-decoration: none;
   width: max-content;
   ${({ theme: { allColors } }) => css`
-    a {
-      color: ${allColors.primary};
+    && {
+      color: ${allColors.fg};
     }
   `}
 `;

--- a/packages/ui/components/CtaLink/index.tsx
+++ b/packages/ui/components/CtaLink/index.tsx
@@ -4,12 +4,17 @@ import React from 'react';
 import Link from 'next/link';
 import type { PayLoadLink } from '@mono/types/payload-types';
 import { ctaEvalHref } from '@mono/ui/utils/ctaEvalHref';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 // UPDATE TO USE THEMECOLOR
 const LinkStyled = styled(Link)`
   text-decoration: none;
   width: max-content;
+  ${({ theme: { allColors } }) => css`
+    a {
+      color: ${allColors.primary};
+    }
+  `}
 `;
 
 export type CtaLinkType = {

--- a/packages/ui/components/Footer/index.tsx
+++ b/packages/ui/components/Footer/index.tsx
@@ -5,14 +5,17 @@ import type { FooterItems } from '@mono/types/payload-types';
 import CtaLink from '@mono/ui/components/CtaLink';
 import ResponsivePayloadImage from '@mono/ui/components/primitives/ResponsivePayloadImage';
 import RichText from '@mono/ui/components/primitives/RichText';
-import styled from '@refract-ui/sc';
+import styled, { css } from '@refract-ui/sc';
 
 const Container = styled.footer`
-  background: white;
-  width: 100%;
-  position: relative;
-  bottom: 0;
-  align-self: end;
+  ${({ theme: { allColors } }) => css`
+    color: ${allColors.fg};
+    background-color: ${allColors.bg};
+    width: 100%;
+    position: relative;
+    bottom: 0;
+    align-self: end;
+  `}
 `;
 
 const ContentWrapper = styled.div`
@@ -38,8 +41,10 @@ const Logo = styled(ResponsivePayloadImage)`
 `;
 
 const Copyright = styled.div`
-  grid-area: copyright;
-  color: black;
+  ${({ theme: { allColors } }) => css`
+    grid-area: copyright;
+    color: ${allColors.fg};
+  `}
 `;
 
 const FlatLinkSection = styled.div`

--- a/packages/ui/components/GeneralCard/index.tsx
+++ b/packages/ui/components/GeneralCard/index.tsx
@@ -63,7 +63,7 @@ const ImageContainer = styled.div`
 const ButtonsWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  ${({ theme: { spacing, mq } }) => css`
+  ${({ theme: { spacing } }) => css`
     margin-top: ${spacing[9]}rem;
     gap: ${spacing[6]}rem;
   `}

--- a/packages/ui/components/GeneralCard/index.tsx
+++ b/packages/ui/components/GeneralCard/index.tsx
@@ -66,10 +66,6 @@ const ButtonsWrapper = styled.div`
   ${({ theme: { spacing, mq } }) => css`
     margin-top: ${spacing[9]}rem;
     gap: ${spacing[6]}rem;
-
-    ${mq.md`
-      flex-wrap: initial;
-    `}
   `}
 `;
 

--- a/packages/ui/components/GeneralCard/index.tsx
+++ b/packages/ui/components/GeneralCard/index.tsx
@@ -13,9 +13,10 @@ const Container = styled.div`
     display: flex;
     flex-direction: column;
     border-radius: 1.13rem;
-    background-color: ${allColors.primaryBg};
+    background-color: ${allColors.fg};
     max-width: 30rem;
     padding: ${spacing[9]}rem;
+    color: ${allColors.bg};
   `}
 `;
 
@@ -40,7 +41,7 @@ const Headline = styled.h1`
 
   ${({ theme: { box } }) => css`
     ${box.t('h3')};
-    ${box.c('primaryFg')};
+    ${box.c('bg')};
   `}
 `;
 

--- a/packages/ui/components/Header/index.tsx
+++ b/packages/ui/components/Header/index.tsx
@@ -78,9 +78,6 @@ const DesktopRow = styled.div`
   ${({ theme: { mq } }) => mq.md`
     grid-area: buttons;
     display: flex;
-    a {
-      color: black;
-    }
   `}
 `;
 

--- a/packages/ui/components/Header/index.tsx
+++ b/packages/ui/components/Header/index.tsx
@@ -24,7 +24,10 @@ const OuterHeader = styled.header`
   position: sticky;
   top: 0;
   z-index: 50;
-  color: white;
+  ${({ theme: { allColors } }) => css`
+    color: ${allColors.fg};
+    background-color: ${allColors.bg};
+  `}
 `;
 
 const NavContainer = styled.div<{ $open: boolean }>`
@@ -44,7 +47,6 @@ const NavContainer = styled.div<{ $open: boolean }>`
       grid-template-areas: "nav buttons";
       padding: .5rem 1.875rem;
       gap: 0;
-      background-color: currentColor;
     `}
   `}
 `;
@@ -110,14 +112,14 @@ const DrawerButton = styled.button`
 `;
 
 const MobileColumn = s(motion.div)`
-  ${({ theme: { mq } }) => css`
+  ${({ theme: { mq, allColors } }) => css`
     position: absolute;
     top: 6rem;
     padding-top: 3rem;
-    background-color: currentColor;
     width: 100%;
     height: 100svh;
     overflow-y: auto;
+    background-color: ${allColors.bg};
 
     ${mq.md`
       display: none;
@@ -129,22 +131,22 @@ const Nav = styled.nav`
   padding: 0.5rem 1.5rem;
   display: grid;
   grid-area: nav;
-  background-color: currentColor;
   align-items: center;
   grid-template-columns: min-content 1fr;
 `;
 
 const NavContentWrapper = styled.div`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  background-color: currentColor;
-  align-items: center;
-  gap: 2rem;
+  ${({ theme: { mq } }) => css`
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2rem;
 
-  ${({ theme: { mq } }) => mq.md`
-    flex-direction: row;
-    gap: 1rem;
+    ${mq.md`
+      flex-direction: row;
+      gap: 1rem;
+    `}
   `}
 `;
 
@@ -214,7 +216,10 @@ function NavContent({
         iconItems.map((item) => {
           return (
             <DesktopIconLink href={item.href as string} key={`icon-${item.id}`}>
-              <RenderIcon {...item.icon} />
+              <RenderIcon
+                {...item.icon}
+                color={item?.icon?.color || '#FFFFFF'}
+              />
             </DesktopIconLink>
           );
         })}
@@ -258,15 +263,18 @@ function Header({
                     href={item.href as string}
                     key={`icon-${item.id}`}
                   >
-                    <RenderIcon {...item.icon} />
+                    <RenderIcon
+                      {...item.icon}
+                      color={item?.icon?.color || '#FFFFFF'}
+                    />
                   </MobileIconLink>
                 );
               })}
             <DrawerButton onClick={() => setOpen(!open)} aria-label="Open Menu">
               {open ? (
-                <RenderIcon name="Close" size="25" />
+                <RenderIcon name="Close" size="25" color="#FFFFFF" />
               ) : (
-                <RenderIcon name="Hamburger" size="25" />
+                <RenderIcon name="Hamburger" size="25" color="#FFFFFF" />
               )}
             </DrawerButton>
           </Row>

--- a/packages/ui/icons/core/Hamburger.tsx
+++ b/packages/ui/icons/core/Hamburger.tsx
@@ -16,7 +16,7 @@ function SvgHamburger(props: SVGProps<SVGSVGElement>) {
     >
       <path
         d="M2.5 15H17.5"
-        stroke="black"
+        stroke={color || '#0C0E0F'}
         strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -24,7 +24,7 @@ function SvgHamburger(props: SVGProps<SVGSVGElement>) {
       />
       <path
         d="M2.5 10H17.5"
-        stroke="black"
+        stroke={color || '#0C0E0F'}
         strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -32,7 +32,7 @@ function SvgHamburger(props: SVGProps<SVGSVGElement>) {
       />
       <path
         d="M2.5 5H17.5"
-        stroke="black"
+        stroke={color || '#0C0E0F'}
         strokeWidth="1.6"
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[DCH-25](https://graveflex.atlassian.net/browse/DCH-25)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

- Update Button styles 
   - remove `rounded-outline` variant and replace with standard `solid` | `outline` | `link` varaints 
   - Clean up theme color usage 
   - remove specific hover styles and default hovers to invert the button style... i.e if button variant is `solid` on hover it will show the `outline` styles 
   - Reduce height and remove min-width
   - remove psuedo `span` tag to alway have a semantic `button` tag wrapper 
   - enable only icon styles 
   - tweaks to `CTAButton` and `CTALink` to accommodate changes. 

- Add demo theme 
   - add basic theme colors overrides
   - add basic colorTokens overrides 
   - use theme colors for `Header` | `Footer` | `GeneralCard` components 

![screencapture-localhost-3000-2024-06-14-15_19_45](https://github.com/graveflex/nextjs-vercel/assets/32271860/999e0dd8-7d7d-4203-8c89-6a5d73e79532)


<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
