### PR TITLE
feat(seeds): kitchen sink block seeder [DCH-17]

### DIFF
--- a/apps/web/bin/seed_blog.ts
+++ b/apps/web/bin/seed_blog.ts
@@ -167,8 +167,6 @@ const seedPosts = async ({ payload, count = 10 }: SeedFnProps) => {
     height: 1000
   });
 
-  console.log('authors', authors);
-
   console.info(`@-->seeding ${count} posts`);
   for (let i = 0; i < count; i += 1) {
     const title = faker.lorem.sentence();

--- a/apps/web/bin/seed_kitchen-sink.ts
+++ b/apps/web/bin/seed_kitchen-sink.ts
@@ -1,0 +1,378 @@
+import { faker } from '@faker-js/faker';
+import type {
+  CardGridBlockT,
+  FAQBlockT,
+  HeroBlockT,
+  MarkdownBlockT,
+  TextImageBlockT
+} from '@mono/types/payload-types';
+import genRichText from '@mono/ui/utils/genRichText';
+import fs from 'fs';
+import path from 'path';
+import type { BasePayload, GeneratedTypes } from 'payload';
+import { getPayload } from 'payload';
+import { importConfig } from 'payload/node';
+import tmp from 'tmp';
+
+interface SeedFnProps {
+  payload: BasePayload<GeneratedTypes>;
+  count?: number;
+}
+
+async function downloadImage(url: string): Promise<string> {
+  try {
+    // Fetch the image
+    const response = await fetch(url);
+
+    // Check if response is ok
+    if (!response.ok) {
+      throw new Error(`Failed to fetch image. Status: ${response.status}`);
+    }
+
+    // Convert response body to buffer
+    const arrayBuffer = await response.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+
+    // Create a temporary file
+    const tempFile = tmp.fileSync({ postfix: '.jpg' });
+
+    // Write image data to the temporary file
+    fs.writeFileSync(tempFile.name, buffer);
+
+    // Return the path to the temporary file
+    return tempFile.name;
+  } catch (error) {
+    console.error('Error downloading image:', error);
+    throw error;
+  }
+}
+
+const downloadImages = ({
+  count = 10,
+  category = 'abstract',
+  width = 640,
+  height = 480
+}) => {
+  const promises = [];
+  for (let i = 0; i < count; i += 1) {
+    promises.push(
+      downloadImage(
+        faker.image.urlLoremFlickr({
+          category,
+          width,
+          height
+        })
+      )
+    );
+  }
+
+  return Promise.all(promises);
+};
+
+const seedImages = async ({
+  payload,
+  count = 10,
+  category = 'abstract',
+  width = 640,
+  height = 480
+}: SeedFnProps & { category?: string; width?: number; height?: number }) => {
+  console.info(`@-->seeding ${count} ${category} images`);
+  const promises = [];
+
+  const images = await downloadImages({ count, category, width, height });
+
+  for (let i = 0; i < count; i += 1) {
+    promises.push(
+      payload.create({
+        collection: 'images',
+        data: {
+          alt: faker.lorem.sentence()
+        },
+        filePath: images[i]
+      })
+    );
+  }
+
+  return Promise.all(promises);
+};
+
+const markdownBlock = {
+  id: '6669d7bd6d58e03f8e7c1077',
+  blockName: 'Markdown Hero Block',
+  blockType: 'markdownBlock',
+  content: {
+    ...genRichText([
+      {
+        type: 'heading',
+        tag: 'h1',
+        text: 'Welcome to the Kitchen Sink (h1)'
+      },
+      {
+        type: 'paragraph',
+        text: faker.lorem.sentence()
+      },
+      {
+        type: 'heading',
+        tag: 'h2',
+        text: 'Welcome to the Kitchen Sink (h2)'
+      },
+      {
+        type: 'heading',
+        tag: 'h3',
+        format: 'center',
+        text: 'Welcome to the Kitchen Sink (h3 - center)'
+      },
+      {
+        type: 'heading',
+        tag: 'h4',
+        format: 'right',
+        text: 'Welcome to the Kitchen Sink (h4 - right)'
+      },
+      {
+        type: 'heading',
+        tag: 'h5',
+        format: 'strikethrough',
+        text: 'Welcome to the Kitchen Sink (h5 - strikethrough)'
+      },
+      {
+        type: 'heading',
+        tag: 'h6',
+        text: 'Welcome to the Kitchen Sink (h6)'
+      },
+      {
+        type: 'paragraph',
+        format: 'bold',
+        text: faker.lorem.sentence()
+      },
+      {
+        type: 'paragraph',
+        format: 'italic',
+        text: faker.lorem.sentence()
+      },
+      {
+        type: 'paragraph',
+        format: 'underline',
+        text: faker.lorem.sentence()
+      }
+    ])
+  },
+  maxWidth: null
+};
+
+const heroBlock = {
+  id: '6669d7bd6d58e03f8e7c1078',
+  blockType: 'heroBlock',
+  layout: 'contentLeft',
+  eyebrow: 'SOME TAGLINE',
+  content: {
+    ...genRichText([
+      {
+        type: 'heading',
+        tag: 'h1',
+        text: 'Test Hero Block'
+      },
+      {
+        type: 'paragraph',
+        text: faker.lorem.sentence()
+      }
+    ])
+  }
+};
+
+const imageTextBlock = {
+  id: '6669d7bd6d58e03f8e7c1079',
+  blockType: 'textImageBlock',
+  content: {
+    ...genRichText([
+      {
+        type: 'heading',
+        tag: 'h2',
+        text: 'Test Image Text Block'
+      },
+      {
+        type: 'paragraph',
+        text: faker.lorem.sentence()
+      }
+    ])
+  }
+};
+
+const cardGridBlock = {
+  id: '6669d7bd6d58e03f8e7c107a',
+  blockName: 'Card Grid Block',
+  blockType: 'cardGridBlock',
+  blockConfig: {
+    contentWidth: 'xxl'
+  }
+};
+
+const faqBlock = {
+  id: '6669d7bd6d58e03f8e7c107b',
+  blockName: 'FAQ Block',
+  blockType: 'faqBlock',
+  blockConfig: {
+    contentWidth: 'xl'
+  },
+  header: {
+    ...genRichText([
+      {
+        type: 'heading',
+        tag: 'h2',
+        text: 'Frequently Asked Questions'
+      }
+    ])
+  },
+  items: [
+    {
+      title: faker.lorem.sentence(),
+      content: {
+        ...genRichText([
+          {
+            type: 'paragraph',
+            text: faker.lorem.paragraph()
+          }
+        ])
+      }
+    },
+    {
+      title: faker.lorem.sentence(),
+      content: {
+        ...genRichText([
+          {
+            type: 'paragraph',
+            text: faker.lorem.paragraph()
+          }
+        ])
+      }
+    },
+    {
+      title: faker.lorem.sentence(),
+      content: {
+        ...genRichText([
+          {
+            type: 'paragraph',
+            text: faker.lorem.paragraph()
+          }
+        ])
+      }
+    }
+  ]
+};
+
+const seedKitchenSinkPage = async ({ payload, count = 10 }: SeedFnProps) => {
+  console.info(`@-->seeding the kitchenSink!`);
+
+  const images = await seedImages({ payload, count, category: 'abstract' });
+
+  await payload.create({
+    collection: 'pages',
+    data: {
+      pageTitle: 'Kitchen Sink',
+      slug: 'kitchen-sink',
+      blocks: [
+        {
+          ...(heroBlock as HeroBlockT),
+          blockName: 'Hero Block Bacground Image',
+          blockConfig: {
+            contentWidth: 'xxl',
+            backgroundImage: images[0].id
+          }
+        },
+        {
+          ...(heroBlock as HeroBlockT),
+          blockName: 'Hero Block Image Right + CTA',
+          blockConfig: {
+            contentWidth: 'xl'
+          },
+          image: images[5].id,
+          cta: {
+            link: {
+              type: 'external',
+              label: 'Read More',
+              externalHref: '/blog'
+            }
+          }
+        },
+        {
+          ...(heroBlock as HeroBlockT),
+          blockName: 'Hero Block Image Left + Form',
+          blockConfig: {
+            contentWidth: 'xl'
+          },
+          layout: 'contentRight',
+          image: images[5].id,
+          form: {
+            textinput: {
+              placeholder: 'email address'
+            },
+
+            cta: {
+              link: {
+                type: 'external',
+                label: 'Learn more',
+                externalHref: 'https://google.com',
+                newTab: true
+              }
+            }
+          }
+        },
+        {
+          ...(imageTextBlock as TextImageBlockT),
+          blockName: 'Text Image Block (image left)',
+          layout: 'imgLeft',
+          image: images[2].id
+        },
+        markdownBlock as MarkdownBlockT,
+        {
+          ...(imageTextBlock as TextImageBlockT),
+          blockName: 'Text Image Block (image right)',
+          layout: 'imgRight',
+          image: images[1].id
+        },
+        {
+          ...(cardGridBlock as CardGridBlockT),
+          cards: [
+            {
+              id: '6669d7bd6d58e03f8e7c107b',
+              card: {
+                image: images[3].id,
+                headline: 'Card 1',
+                subHead: faker.lorem.sentence()
+              }
+            },
+            {
+              id: '6669d7bd6d58e03f8e7c10xx',
+              card: {
+                image: images[4].id,
+                headline: 'Card 2',
+                subHead: faker.lorem.sentence()
+              }
+            },
+            {
+              id: '6669d7bd6d58e03f8e7c1xxx',
+              card: {
+                image: images[0].id,
+                headline: 'Card 3',
+                subHead: faker.lorem.sentence()
+              }
+            }
+          ]
+        },
+        faqBlock as FAQBlockT
+      ]
+    }
+  });
+};
+
+const seed = async (): Promise<void> => {
+  const configPath = path.resolve(__dirname, '../payload.config.ts');
+  const config = await importConfig(configPath);
+  const payload = await getPayload({ config });
+  // await seedImages({ payload });
+  await seedKitchenSinkPage({ payload });
+  console.info('@-->successfully seeded the kitchen sink!');
+
+  process.exit(0);
+};
+
+export default seed();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,8 +16,10 @@
     "migrations:create": "payload migrate:create",
     "migrations:run": "if [ \"$CI\" != \"true\" ]; then payload migrate; fi",
     "setup": "./bin/init_db.sh",
+    "seed:kitchenSink": "tsx ./bin/seed_kitchen-sink.ts",
     "seed:nav": "tsx ./bin/seed-nav.ts",
-    "seed:blog": "tsx ./bin/seed_blog.ts"
+    "seed:blog": "tsx ./bin/seed_blog.ts",
+    "seed:all": "pnpm seed:nav && pnpm seed:blog && pnpm seed:kitchenSink"
   },
   "dependencies": {
     "@faker-js/faker": "^8.4.0",


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[DCH-17](https://graveflex.atlassian.net/browse/DCH-17)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

<!-- /description -->
- Adds a new seed for a `kitchen-sink` page that populates all the available blocks with test data 
- updates the `nav` seed to assign a logo for the header and footer and adds a hero block to the homepage. 

from `apps/web` 

run `pnpm seed:kitchenSink` 

or after a fresh migration run `pnpm seed:all` which will seed the nav, blog, and kitchenSink pages 

<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
