### PR TITLE
feat(Base Components) Text Image & Hero Revisions

### DIFF
--- a/apps/web/src/blocks/HeroBlock/HeroBlock.stories.tsx
+++ b/apps/web/src/blocks/HeroBlock/HeroBlock.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<HeroBlockProps>;
 export const Defaults: Story = {
   args: {
     blockConfig: {
-      contentWidth: 'xxl'
+      contentWidth: 'xl'
     },
     layout: 'contentLeft',
     content: {
@@ -65,7 +65,7 @@ export const Defaults: Story = {
 export const ContentRight: Story = {
   args: {
     blockConfig: {
-      contentWidth: 'xxl'
+      contentWidth: 'xl'
     },
     layout: 'contentRight',
     content: {
@@ -110,7 +110,7 @@ export const ContentRight: Story = {
 export const ContentCenter: Story = {
   args: {
     blockConfig: {
-      contentWidth: 'xxl'
+      contentWidth: 'xl'
     },
     layout: 'contentCenter',
     contentAlign: 'center',
@@ -184,7 +184,7 @@ export const FullBleed: Story = {
 export const BackgroundImage: Story = {
   args: {
     blockConfig: {
-      contentWidth: 'xxl',
+      contentWidth: 'xl',
       backgroundImage: {
         id: 1,
         alt: 'Myopic Logo',
@@ -226,7 +226,7 @@ export const BackgroundImage: Story = {
 export const CTANoForm: Story = {
   args: {
     blockConfig: {
-      contentWidth: 'xxl'
+      contentWidth: 'xl'
     },
     layout: 'contentLeft',
     content: {

--- a/apps/web/src/blocks/HeroBlock/index.tsx
+++ b/apps/web/src/blocks/HeroBlock/index.tsx
@@ -14,8 +14,11 @@ export type HeroBlockProps = Omit<PayloadType, 'blockType'>;
 
 const StyledWrapper = s(Wrapper)``;
 
-const InnerWrapper = s.div<{ $isFullBleed: boolean; $layout: string }>`
-  ${({ $layout, $isFullBleed, theme: { mq } }) => css`
+const InnerWrapper = s.div<{
+  $hasImage: boolean;
+  $layout: string;
+}>`
+  ${({ $layout, $hasImage, theme: { mq } }) => css`
     display: grid;
     grid-template-columns: 1fr;
     align-items: center;
@@ -24,15 +27,16 @@ const InnerWrapper = s.div<{ $isFullBleed: boolean; $layout: string }>`
     margin: auto;
 
     ${mq.lg`
-      padding: ${$isFullBleed ? '0' : '0 3.125rem'};
       ${
         ($layout === 'contentLeft' || $layout === 'contentRight') &&
+        $hasImage &&
         css`
           grid-template-columns: 1fr 1fr;
         `
       }
       ${
         $layout === 'contentCenter' &&
+        !$hasImage &&
         css`
           grid-template-columns: 1fr;
         `
@@ -44,7 +48,7 @@ const InnerWrapper = s.div<{ $isFullBleed: boolean; $layout: string }>`
 const Eyebrow = s.span({ t: 'h6', c: 'fg' })`
 `;
 
-const Content = s(RichText)`
+const Content = s(RichText)<{ $hasImage: boolean }>`
   h1,
   h2,
   h3,
@@ -57,15 +61,15 @@ const Content = s(RichText)`
 
 const ContentWrapper = s.div<{
   $isFullBleed: boolean;
+  $hasImage: boolean;
   $contentAlign: string;
   $layout: string;
 }>`
-  ${({ $contentAlign, $isFullBleed, $layout, theme: { mq } }) => css`
+  ${({ $contentAlign, $isFullBleed, $hasImage, $layout, theme: { mq } }) => css`
     display: flex;
     flex-direction: column;
     justify-content: center;
-    max-width: 33.75rem;
-    padding: 0 2rem;
+    max-width: ${$hasImage ? 'unset' : '80%'};
     order: 1;
 
     ${$contentAlign === 'center' &&
@@ -84,7 +88,7 @@ const ContentWrapper = s.div<{
         $layout === 'contentLeft' &&
         css`
           order: 0;
-          margin: 0 0 0 auto;
+          margin: ${$hasImage ? '0 auto 0 0' : '0 auto 0 0'};
           padding: ${$isFullBleed ? '0 0 0 2rem' : '0'};
         `
       }
@@ -93,13 +97,13 @@ const ContentWrapper = s.div<{
         $layout === 'contentRight' &&
         css`
           order: 1;
-          margin: 0 auto 0 0;
+          margin: ${$hasImage ? '0 0 0 auto' : '0 0 0 auto'};
           padding: ${$isFullBleed ? '0 2rem 0 0' : '0'};
         `
       }
 
       ${
-        $layout === 'contentCenter' &&
+        ($layout === 'contentCenter' || $contentAlign === 'center') &&
         css`
           margin: 0 auto;
           padding: ${$isFullBleed ? '0 2rem' : '0'};
@@ -165,6 +169,8 @@ function HeroBlock({
   contentAlign,
   layout
 }: HeroBlockProps) {
+  const hasImage = typeof image !== 'undefined';
+
   const isFullBleed =
     typeof image === 'object' && typeof image?.imageProps?.fill === 'boolean'
       ? image?.imageProps?.fill
@@ -175,18 +181,19 @@ function HeroBlock({
 
   return (
     <StyledWrapper
-      gutter={false}
       {...blockConfig}
+      gutter={isFullBleed ? false : 'blockH'}
       hidden={blockConfig?.hidden ?? false}
     >
-      <InnerWrapper $layout={contentPosition} $isFullBleed={isFullBleed}>
+      <InnerWrapper $layout={contentPosition} $hasImage={hasImage}>
         <ContentWrapper
           $layout={contentPosition}
           $isFullBleed={isFullBleed}
           $contentAlign={alignText}
+          $hasImage={hasImage}
         >
           {eyebrow && <Eyebrow>{eyebrow}</Eyebrow>}
-          {content && <Content {...content} />}
+          {content && <Content $hasImage={hasImage} {...content} />}
           {form?.textinput?.placeholder && form?.cta && (
             <InputWrapper
               onSubmit={(data) => console.log(data)}
@@ -201,7 +208,7 @@ function HeroBlock({
               />
             </InputWrapper>
           )}
-          {cta && (
+          {cta?.link?.label && (
             <ButtonWrapper>
               <CtaButton cta={cta} color="primary" />
             </ButtonWrapper>

--- a/apps/web/src/blocks/TextImageBlock/TextImageBlock.stories.tsx
+++ b/apps/web/src/blocks/TextImageBlock/TextImageBlock.stories.tsx
@@ -21,7 +21,8 @@ export const LeftImageButton: Story = {
   args: {
     blockConfig: {
       theme: 'light',
-      hidden: false
+      hidden: false,
+      contentWidth: 'xl'
     },
     layout: 'imgLeft',
     content: {
@@ -69,7 +70,8 @@ export const RightImageButton: Story = {
   args: {
     blockConfig: {
       theme: 'dark',
-      hidden: false
+      hidden: false,
+      contentWidth: 'xl'
     },
     layout: 'imgRight',
     content: {
@@ -117,7 +119,8 @@ export const LeftImage: Story = {
   args: {
     blockConfig: {
       theme: 'light',
-      hidden: false
+      hidden: false,
+      contentWidth: 'xl'
     },
     layout: 'imgLeft',
     content: {
@@ -147,7 +150,8 @@ export const RightImage: Story = {
   args: {
     blockConfig: {
       theme: 'dark',
-      hidden: false
+      hidden: false,
+      contentWidth: 'xl'
     },
     layout: 'imgRight',
     content: {
@@ -177,7 +181,8 @@ export const LeftImageForm: Story = {
   args: {
     blockConfig: {
       theme: 'light',
-      hidden: false
+      hidden: false,
+      contentWidth: 'xl'
     },
     layout: 'imgLeft',
     content: {
@@ -218,7 +223,8 @@ export const LeftImageVideo: Story = {
   args: {
     blockConfig: {
       theme: 'light',
-      hidden: false
+      hidden: false,
+      contentWidth: 'xl'
     },
     layout: 'imgLeft',
     content: {

--- a/apps/web/src/blocks/TextImageBlock/index.tsx
+++ b/apps/web/src/blocks/TextImageBlock/index.tsx
@@ -66,18 +66,21 @@ const ContentWrapper = s.div<{ $hasButton: boolean; $layout: string }>`
 
     ${$hasButton && 'align-self: center;'}
 
-    ${($layout === 'imgLeftCenter' || $layout === 'imgLeft') &&
-    css`
-      margin-right: auto;
-    `}
 
-    ${$layout === 'imgRight' &&
-    css`
-      margin-left: auto;
-    `}
+  ${mq.lg`
+      ${
+        ($layout === 'imgLeftCenter' || $layout === 'imgLeft') &&
+        css`
+          margin-left: auto;
+        `
+      }
 
-    ${mq.lg`
-      max-width: 70%
+      ${
+        $layout === 'imgRight' &&
+        css`
+          margin-right: auto;
+        `
+      }
     `}
   `}
 `;
@@ -114,7 +117,7 @@ const Content = s(RichText)<{ $layout: string }>`
 `;
 
 const ImageWrapper = s(ResponsivePayloadImage)<{ $layout: string }>`
-  ${({ $layout }) => css`
+  ${({ $layout, theme: { mq } }) => css`
     grid-area: image;
     overflow: hidden;
     align-self: center;
@@ -123,14 +126,20 @@ const ImageWrapper = s(ResponsivePayloadImage)<{ $layout: string }>`
       height: auto;
     }
 
-    ${($layout === 'imgLeftCenter' || $layout === 'imgLeft') &&
-    css`
-      margin-left: auto;
-    `}
+    ${mq.lg`
+    ${
+      ($layout === 'imgLeftCenter' || $layout === 'imgLeft') &&
+      css`
+        margin-right: auto;
+      `
+    }
 
-    ${$layout === 'imgRight' &&
-    css`
-      margin-right: auto;
+    ${
+      $layout === 'imgRight' &&
+      css`
+        margin-left: auto;
+      `
+    }
     `}
   `}
 `;

--- a/apps/web/src/payload/fields/TextInput.ts
+++ b/apps/web/src/payload/fields/TextInput.ts
@@ -11,7 +11,7 @@ function TextInput({
     interfaceName: interfaceName || 'TextInputType',
     fields: [
       {
-        label: 'CTA Settings',
+        label: 'Input Settings',
         type: 'collapsible',
         admin: {
           initCollapsed: true


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[DCH-35](https://graveflex.atlassian.net/browse/DCH-35)
[DCH-36](https://graveflex.atlassian.net/browse/DCH-34)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

Fixing `TextImageBlock` & `HeroBlock` so the content aligns to the gutter of the page body instead of the center line of its inner column.

Adjusted `HeroBlock` so when there isn't an image the content spans further across the page

Conditionally hiding button on `TextImageBlock`

<img width="600" alt="Screenshot 2024-06-25 at 3 19 32 PM" src="https://github.com/graveflex/nextjs-vercel/assets/90799803/6b9a5385-49cb-45ec-b28c-b48b5c557ca2">



<!-- /description -->
<!-- Describe the ask/feature associated with the ticket and how it was implemented -->
<!-- Are there any known/expected issues w/ this update that should be noted for QA? -->

<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
