### PR TITLE
Feat(performance):  image op / loading suspense / sitemap

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -76,6 +76,9 @@ export default withPayload(
       return config;
     },
     images: {
+      formats: ['image/avif', 'image/webp'],
+      deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048],
+      imageSizes: [16, 32, 48, 64, 96, 128, 256],
       remotePatterns: [
         {
           protocol: 'https',

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -80,6 +80,7 @@
     "ramda": "^0.30.0",
     "react": "latest",
     "react-dom": "latest",
+    "react-loader-spinner": "^6.1.6",
     "react-hook-form": "^7.51.3",
     "sharp": "0.33.3",
     "styled-components": "latest",

--- a/apps/web/src/app/(app)/[locale]/[[...slug]]/page.client.tsx
+++ b/apps/web/src/app/(app)/[locale]/[[...slug]]/page.client.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { WEB_URL } from '@mono/settings';
 import type { Nav, Page } from '@mono/types/payload-types';
 import BlocksRenderer from '@mono/web/components/BlocksRenderer';
+import Loading from '@mono/web/components/Loading';
 import Layout from '@mono/web/globals/Layout';
 import useLivePreview from '@mono/web/hooks/useLivePreview';
 
@@ -24,7 +25,9 @@ function PageTemplate({ page, nav }: { page: Page; nav: Nav }) {
 
   return (
     <Layout theme={theme} {...nav}>
-      <BlocksRenderer blocks={blocks} />
+      <Suspense fallback={<Loading />}>
+        <BlocksRenderer blocks={blocks} />
+      </Suspense>
     </Layout>
   );
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,85 @@
+import type { MetadataRoute } from 'next';
+import { WEB_URL } from '@mono/settings';
+import type { Page, Post } from '@mono/types/payload-types';
+import fetchPayloadDataRest from '@mono/web/lib/fetchPayloadDataRest';
+import type { PaginatedDocs } from 'payload';
+
+export default async function Sitemap(): Promise<MetadataRoute.Sitemap> {
+  const [postData, pageData] = await Promise.all([
+    fetchPayloadDataRest<PaginatedDocs<Post>>({
+      endpoint: '/api/posts',
+      params: {
+        limit: 0
+      }
+    }),
+    fetchPayloadDataRest<PaginatedDocs<Page>>({
+      endpoint: '/api/pages',
+      params: {
+        limit: 0
+      }
+    })
+  ]);
+
+  if ('error' in postData || 'error' in pageData) {
+    return [];
+  }
+
+  const postDocs = postData.docs;
+  const pageDocs = pageData.docs;
+
+  const pagesAndPosts = () => {
+    const sitemap: MetadataRoute.Sitemap = [];
+
+    pageDocs.map((item) => {
+      if (item.slug !== '/') {
+        sitemap.push({
+          changeFrequency: 'weekly',
+          lastModified: item.updatedAt,
+          priority: 1,
+          url: `${WEB_URL}/${item.slug}`,
+          alternates: {
+            languages: {
+              en: `${WEB_URL}/en-us/${item.slug}`,
+              es: `${WEB_URL}/es-us/${item.slug}`
+            }
+          }
+        });
+      }
+      return sitemap;
+    });
+
+    postDocs.map((item) => {
+      sitemap.push({
+        changeFrequency: 'weekly',
+        lastModified: item.updatedAt,
+        priority: 1,
+        url: `${WEB_URL}/blog/${item.slug}`,
+        alternates: {
+          languages: {
+            en: `${WEB_URL}/en-us/blog/${item.slug}`,
+            es: `${WEB_URL}/es-us/blog/${item.slug}`
+          }
+        }
+      });
+
+      return sitemap;
+    });
+    return sitemap;
+  };
+
+  return [
+    ...pagesAndPosts(),
+    {
+      url: WEB_URL,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+      alternates: {
+        languages: {
+          en: `${WEB_URL}/en-us/`,
+          es: `${WEB_URL}/es-us/`
+        }
+      }
+    }
+  ];
+}

--- a/apps/web/src/components/Loading/index.tsx
+++ b/apps/web/src/components/Loading/index.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+import { RotatingLines } from 'react-loader-spinner';
+import s from '@refract-ui/sc';
+
+const Container = s.div`
+  width: 100%;
+  height: 100%;
+  display: grid;
+  align-self: stretch;
+  justify-self: stretch;
+  align-items: center;
+  justify-content: center;
+`;
+
+function Loading() {
+  return (
+    <Container>
+      <RotatingLines />
+    </Container>
+  );
+}
+
+export default Loading;

--- a/packages/ui/components/primitives/ResponsivePayloadImage/index.tsx
+++ b/packages/ui/components/primitives/ResponsivePayloadImage/index.tsx
@@ -157,6 +157,7 @@ function ResponsivePayloadImage({
       <Source breakpoints={breakpoints} image={mobile} bp="sm" />
       <Source breakpoints={breakpoints} image={thumbnail} bp="xxs" />
       <ResponsiveImage
+        loading={imageProps?.priority ? 'eager' : 'lazy'}
         $additionalProps={additionalProps}
         {...{
           ...dimensions,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,6 +55,7 @@
     "vitest-canvas-mock": "^0.3.3"
   },
   "dependencies": {
-    "@types/styled-components": "latest"
+    "@types/styled-components": "latest",
+    "react-loader-spinner": "^6.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       react-hook-form:
         specifier: ^7.51.3
         version: 7.52.2(react@19.0.0-rc-fb9a90fa48-20240614)
+      react-loader-spinner:
+        specifier: ^6.1.6
+        version: 6.1.6(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
       sharp:
         specifier: 0.32.6
         version: 0.32.6
@@ -579,6 +582,9 @@ importers:
       '@types/styled-components':
         specifier: ^5.1.34
         version: 5.1.34
+      react-loader-spinner:
+        specifier: ^6.1.6
+        version: 6.1.6(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
     devDependencies:
       '@faker-js/faker':
         specifier: ^8.4.0
@@ -7096,6 +7102,13 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-loader-spinner@6.1.6:
+    resolution: {integrity: sha512-x5h1Jcit7Qn03MuKlrWcMG9o12cp9SNDVHVJTNRi9TgtGPKcjKiXkou4NRfLAtXaFB3+Z8yZsVzONmPzhv2ErA==}
+    engines: {node: '>= 12'}
+    peerDependencies:
+      react: ^19.0.0-rc-06d0b89e-20240801
+      react-dom: ^19.0.0-rc-06d0b89e-20240801
 
   react-onclickoutside@6.13.1:
     resolution: {integrity: sha512-LdrrxK/Yh9zbBQdFbMTXPp3dTSN9B+9YJQucdDu3JNKRrbdU+H+/TVONJoWtOwy4II8Sqf1y/DTI6w/vGPYW0w==}
@@ -16125,6 +16138,13 @@ snapshots:
   react-is@18.1.0: {}
 
   react-is@18.3.1: {}
+
+  react-loader-spinner@6.1.6(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614):
+    dependencies:
+      react: 19.0.0-rc-fb9a90fa48-20240614
+      react-dom: 19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614)
+      react-is: 18.3.1
+      styled-components: 6.1.8(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
 
   react-onclickoutside@6.13.1(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614):
     dependencies:


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[TICKET NUMBER](LINK TO TICKET)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description
- implement sitemap.ts (pages and blog)
- image optimization settings
        * update next.config to use next gen image formats
        * cap max image width to ~2048px
        * add loading="lazy" to the ResponsiveImage componen
- adds loading spinner and page lever suspense boundry



<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
