### PR TITLE
fix: enables `disablePayloadAccessControl` for images and videos with vercel blob storage

### DIFF
--- a/apps/web/payload.config.ts
+++ b/apps/web/payload.config.ts
@@ -196,9 +196,13 @@ export default buildConfig({
     vercelBlobStorage({
       enabled: true,
       collections: {
-        [Images.slug]: true,
+        [Images.slug]: {
+          disablePayloadAccessControl: true
+        },
         [Files.slug]: true,
-        [Videos.slug]: true
+        [Videos.slug]: {
+          disablePayloadAccessControl: true
+        }
       },
       token: process.env.BLOB_READ_WRITE_TOKEN as string
     }),


### PR DESCRIPTION
fix: enables `disablePayloadAccessControl` for images and videos with vercel blob storage

<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[TICKET NUMBER](LINK TO TICKET)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description

<!-- /description -->
<!-- Describe the ask/feature associated with the ticket and how it was implemented -->
<!-- Are there any known/expected issues w/ this update that should be noted for QA? -->

<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
