### PR TITLE
fix(blog): Re-add blog and separate data fetching. 

### DIFF
--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.client.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.client.tsx
@@ -3,9 +3,7 @@ import BlogDetail from '@mono/ui/components/BlogDetail';
 import React from 'react';
 
 function PageTemplate({ post }: { post: Post }) {
-  return (
-      <BlogDetail postData={post} />
-  );
+  return <BlogDetail postData={post} />;
 }
 
 export default PageTemplate;

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.client.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.client.tsx
@@ -1,0 +1,11 @@
+import type { Post } from '@mono/types/payload-types';
+import BlogDetail from '@mono/ui/components/BlogDetail';
+import React from 'react';
+
+function PageTemplate({ post }: { post: Post }) {
+  return (
+      <BlogDetail postData={post} />
+  );
+}
+
+export default PageTemplate;

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
@@ -1,0 +1,110 @@
+import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
+import { redirectApi } from '@mono/web/lib/redirectApi';
+import config from '@payload-config';
+import Layout from '@mono/web/globals/Layout';
+import { getPayloadHMR } from '@payloadcms/next/utilities';
+import { unstable_cache } from 'next/cache';
+import { notFound, redirect } from 'next/navigation';
+import React from 'react';
+
+import PageTemplate from './page.client';
+import { de } from '@faker-js/faker';
+
+export const dynamic = 'force-static';
+export const revalidate = 60;
+
+interface BlogDetailProps {
+  params: {
+    locale: LanguageLocale;
+    slug: string[];
+    draft?: boolean;
+  };
+}
+
+export default async function Blog({
+  params: { locale = DEFAULT_LOCALE, slug, draft }
+}: BlogDetailProps) {
+  const pageSlug = slug ? slug.join('/') : '/';
+
+  const fetchPageData = unstable_cache(
+    async (
+      draft: boolean | undefined,
+      locale: LanguageLocale,
+      pageSlug: string
+    ) => {
+      const payload = await getPayloadHMR({ config });
+
+      return Promise.all([
+        payload.find({
+          collection: 'posts',
+          locale,
+          draft,
+          depth: 2,
+          where: {
+            slug: {
+              equals: pageSlug
+            }
+          }
+        })
+      ]);
+    },
+    [[locale, draft, 'blog', pageSlug].filter((x) => x).join('/')]
+  );
+
+  const [postData] = await fetchPageData(draft, locale, pageSlug);
+
+  // if there's an error fetching data, 404
+  if ( 'error' in postData || !postData.docs[0]) {
+    const redirectPath = await redirectApi(pageSlug);
+    if (
+      !redirectPath ||
+      (typeof redirectPath === 'object' && 'error' in redirectPath)
+    ) {
+      return notFound();
+    }
+    redirect(redirectPath);
+  }
+
+  return (
+    <Layout theme={postData.theme} locale={locale} draft={draft}>
+      <PageTemplate post={postData.docs[0]} />
+    </Layout>
+  );
+}
+
+export async function generateMetadata({ params: { slug } }: BlogDetailProps) {
+  const payload = await getPayloadHMR({ config });
+  const pageSlug = slug ? slug.join('/') : '/';
+  try {
+    const data = await payload.find({
+      collection: 'posts',
+      where: {
+        slug: {
+          equals: pageSlug
+        }
+      }
+    });
+
+    if ('error' in data) {
+      return {};
+    }
+
+    const pageData = data?.docs[0];
+    const seoData = data?.docs[0]?.meta;
+    const seoImage =
+      typeof seoData?.image !== 'number' && seoData?.image?.url
+        ? seoData?.image?.url
+        : 'https://ut94wx32cwlqjiry.public.blob.vercel-storage.com/opengraph-IaDqdUZAHTyyH8EfsPaH2oiQFN50MG.jpg';
+
+    return {
+      title: seoData?.title || pageData?.title || 'Blog Post',
+      description: seoData?.description || "Blog post's description",
+      keywords: seoData?.keywords || null,
+      openGraph: {
+        images: [seoImage]
+      }
+    };
+  } catch (_) {
+    return {};
+  }
+}

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
@@ -1,14 +1,13 @@
+import Layout from '@mono/web/globals/Layout';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
 import { redirectApi } from '@mono/web/lib/redirectApi';
 import config from '@payload-config';
-import Layout from '@mono/web/globals/Layout';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 import { unstable_cache } from 'next/cache';
 import { notFound, redirect } from 'next/navigation';
 import React from 'react';
 
 import PageTemplate from './page.client';
-import { de } from '@faker-js/faker';
 
 export const dynamic = 'force-static';
 export const revalidate = 60;
@@ -54,7 +53,7 @@ export default async function Blog({
   const [postData] = await fetchPageData(draft, locale, pageSlug);
 
   // if there's an error fetching data, 404
-  if ( 'error' in postData || !postData.docs[0]) {
+  if ('error' in postData || !postData.docs[0]) {
     const redirectPath = await redirectApi(pageSlug);
     if (
       !redirectPath ||
@@ -66,7 +65,7 @@ export default async function Blog({
   }
 
   return (
-    <Layout theme={postData.theme} locale={locale} draft={draft}>
+    <Layout locale={locale} draft={draft}>
       <PageTemplate post={postData.docs[0]} />
     </Layout>
   );

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/components/posts.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/components/posts.tsx
@@ -38,7 +38,7 @@ export default async function Posts({
         limit: 9
       });
     },
-    [[locale, draft, 'blocks'].filter((x) => x).join('/')]
+    [`${[locale, draft, 'posts'].filter((x) => x).join('/')}?page=${pagPage}`]
   );
 
   const postData = await fetchPostData(draft, locale);

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/components/posts.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/components/posts.tsx
@@ -24,7 +24,7 @@ export default async function Posts({
 }: LayoutProps) {
   'use server';
 
-  const pagPage = searchParams.page ? searchParams.page : '1';
+  const pagPage = searchParams.page;
 
   const fetchPostData = unstable_cache(
     async (draft: boolean | undefined, locale: LanguageLocale) => {

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/components/posts.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/components/posts.tsx
@@ -1,0 +1,47 @@
+import type { LanguageLocale } from '@mono/web/lib/constants';
+import config from '@payload-config';
+import { getPayloadHMR } from '@payloadcms/next/utilities';
+import { unstable_cache } from 'next/cache';
+import PageTemplate from '../page.client';
+
+import type React from 'react';
+
+type LayoutProps = {
+  locale: LanguageLocale;
+  draft?: boolean;
+  searchParams: {
+    page: string;
+    sort: string;
+    filter: string;
+    search: string;
+  };
+};
+
+export default async function Posts({
+  locale,
+  draft,
+  searchParams
+}: LayoutProps) {
+  'use server';
+
+  const pagPage = searchParams.page ? searchParams.page : '1';
+
+  const fetchPostData = unstable_cache(
+    async (draft: boolean | undefined, locale: LanguageLocale) => {
+      const payload = await getPayloadHMR({ config });
+      return payload.find({
+        collection: 'posts',
+        page: parseInt(pagPage, 10),
+        locale,
+        draft,
+        depth: 2,
+        limit: 9
+      });
+    },
+    [[locale, draft, 'blocks'].filter((x) => x).join('/')]
+  );
+
+  const postData = await fetchPostData(draft, locale);
+
+  return <PageTemplate postData={postData} />;
+}

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.client.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.client.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 import type { BlogIndex, Post } from '@mono/types/payload-types';
 import BlogWrapper from '@mono/ui/components/BlogIndex';

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.client.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.client.tsx
@@ -1,21 +1,16 @@
 'use client';
 
-import type { BlogIndex, Post } from '@mono/types/payload-types';
+import type { Post } from '@mono/types/payload-types';
 import BlogWrapper from '@mono/ui/components/BlogIndex';
 import useIndexControls from '@mono/ui/lib/hooks/useIndexControls';
-import BlocksRenderer from '@mono/web/components/BlocksRenderer';
 import type { PaginatedDocs } from 'payload';
 import React from 'react';
 
 function PageTemplate({
-  page,
   postData
 }: {
   postData: PaginatedDocs<Post>;
-  page: BlogIndex;
 }) {
-  const blocks = page?.blocks;
-
   const { setPage, setFilter, setSort, activeSort, activeFilters } =
     useIndexControls();
 
@@ -30,7 +25,6 @@ function PageTemplate({
 
   return (
     <>
-      {blocks && <BlocksRenderer blocks={blocks} />}
       {postData && (
         <BlogWrapper
           posts={postData.docs}

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.client.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.client.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { BlogIndex, Post } from '@mono/types/payload-types';
+import BlogWrapper from '@mono/ui/components/BlogIndex';
+import useIndexControls from '@mono/ui/lib/hooks/useIndexControls';
+import BlocksRenderer from '@mono/web/components/BlocksRenderer';
+import type { PaginatedDocs } from 'payload';
+import React from 'react';
+
+function PageTemplate({
+  page,
+  postData
+}: {
+  postData: PaginatedDocs<Post>;
+  page: BlogIndex;
+}) {
+  const blocks = page?.blocks;
+
+  const { setPage, setFilter, setSort, activeSort, activeFilters } =
+    useIndexControls();
+
+  const pagination = {
+    total: postData.totalDocs,
+    limit: postData.limit,
+    currentPage: (postData?.page ?? 1) - 1,
+    updatePage: (pageNumber: number) => {
+      setPage(pageNumber + 1);
+    }
+  };
+
+  return (
+    <>
+      {blocks && <BlocksRenderer blocks={blocks} />}
+      {postData && (
+        <BlogWrapper
+          posts={postData.docs}
+          activeFilters={activeFilters}
+          activeSort={activeSort}
+          setFilter={setFilter}
+          setSort={setSort}
+          paginationProps={pagination}
+          page={postData.page}
+        />
+      )}
+    </>
+  );
+}
+
+export default PageTemplate;

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -8,7 +8,7 @@ import { notFound } from 'next/navigation';
 import React from 'react';
 import Posts from './components/posts';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 export const revalidate = 60;
 
 interface BlogLayoutProps {
@@ -45,7 +45,9 @@ export default async function Blog({
         */
       ]);
     },
-    [[locale, draft, 'blog'].filter((x) => x).join('/')]
+    [
+      `${[locale, draft, 'blog'].filter((x) => x).join('/')}?page=${searchParams.page}`
+    ]
   );
 
   const [indexData] = await fetchPageData(draft, locale);

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -1,0 +1,114 @@
+import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
+import config from '@payload-config';
+import Layout from '@mono/web/globals/Layout';
+import { getPayloadHMR } from '@payloadcms/next/utilities';
+import { unstable_cache } from 'next/cache';
+import { notFound } from 'next/navigation';
+import React from 'react';
+
+import PageTemplate from './page.client';
+
+export const dynamic = 'force-static';
+export const revalidate = 60;
+
+interface BlogLayoutProps {
+  params: {
+    locale: LanguageLocale;
+    draft?: boolean;
+  };
+  searchParams: {
+    page: string;
+    sort: string;
+    filter: string;
+    search: string;
+  };
+}
+
+export default async function Blog({
+  params: { locale = DEFAULT_LOCALE, draft },
+  searchParams
+}: BlogLayoutProps) {
+  const pagPage = searchParams.page ? searchParams.page : '1';
+
+  const fetchPageData = unstable_cache(
+    async (draft: boolean | undefined, locale: LanguageLocale) => {
+      const payload = await getPayloadHMR({ config });
+      return Promise.all([
+        payload.findGlobal({
+          slug: 'blogIndex',
+          locale,
+          draft
+        }),
+        payload.find({
+          collection: 'posts',
+          page: parseInt(pagPage, 10),
+          locale,
+          limit: 9
+        }),
+        payload.find({
+          collection: 'tags',
+          locale
+        })
+      ]);
+    },
+    [[locale, draft, 'blog'].filter((x) => x).join('/')]
+  );
+
+  const [indexData, postData, filterData] = await fetchPageData(
+    draft,
+    locale
+  );
+
+  // if there's an error fetching data, 404
+  if (
+    'error' in indexData ||
+    'error' in postData ||
+    'error' in filterData
+  ) {
+    return notFound();
+  }
+
+  const page = indexData;
+
+  return <Layout theme={page.theme} locale={locale} draft={draft}><PageTemplate page={page} postData={postData} /></Layout>;
+}
+
+export async function generateMetadata({
+  params: { slug }
+}: {
+  params: { slug?: string[] };
+}) {
+  const payload = await getPayloadHMR({ config });
+  const pageSlug = slug ? slug.join('/') : '/';
+
+  try {
+    const data = await payload.find({
+      collection: 'posts',
+      where: {
+        slug: { equals: pageSlug }
+      },
+      limit: 1
+    });
+
+    if ('error' in data) {
+      return {};
+    }
+
+    const seoData = data?.docs[0]?.meta;
+    const seoImage =
+      typeof seoData?.image !== 'number' && seoData?.image?.url
+        ? seoData?.image?.url
+        : 'https://ut94wx32cwlqjiry.public.blob.vercel-storage.com/opengraph-IaDqdUZAHTyyH8EfsPaH2oiQFN50MG.jpg';
+
+    return {
+      title: seoData?.title || 'Blog',
+      description: seoData?.description || "Blog's description",
+      keywords: seoData?.keywords || null,
+      openGraph: {
+        images: [seoImage]
+      }
+    };
+  } catch (_) {
+    return {};
+  }
+}

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -8,7 +8,7 @@ import { notFound } from 'next/navigation';
 import React from 'react';
 import Posts from './components/posts';
 
-export const dynamic = 'force-dynamic';
+export const dynamic = 'auto';
 export const revalidate = 60;
 
 interface BlogLayoutProps {
@@ -62,6 +62,7 @@ export default async function Blog({
 
   return (
     <Layout theme={page.theme} locale={locale} draft={draft}>
+      <span>{searchParams.page}</span>
       {blocks && <BlocksRenderer blocks={blocks} />}
       <Posts locale={locale} draft={draft} searchParams={searchParams} />
     </Layout>

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -1,6 +1,6 @@
+import Layout from '@mono/web/globals/Layout';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
 import config from '@payload-config';
-import Layout from '@mono/web/globals/Layout';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
 import { unstable_cache } from 'next/cache';
 import { notFound } from 'next/navigation';
@@ -54,23 +54,20 @@ export default async function Blog({
     [[locale, draft, 'blog'].filter((x) => x).join('/')]
   );
 
-  const [indexData, postData, filterData] = await fetchPageData(
-    draft,
-    locale
-  );
+  const [indexData, postData, filterData] = await fetchPageData(draft, locale);
 
   // if there's an error fetching data, 404
-  if (
-    'error' in indexData ||
-    'error' in postData ||
-    'error' in filterData
-  ) {
+  if ('error' in indexData || 'error' in postData || 'error' in filterData) {
     return notFound();
   }
 
   const page = indexData;
 
-  return <Layout theme={page.theme} locale={locale} draft={draft}><PageTemplate page={page} postData={postData} /></Layout>;
+  return (
+    <Layout theme={page.theme} locale={locale} draft={draft}>
+      <PageTemplate page={page} postData={postData} />
+    </Layout>
+  );
 }
 
 export async function generateMetadata({

--- a/packages/ui/components/GeneralCard/index.tsx
+++ b/packages/ui/components/GeneralCard/index.tsx
@@ -55,21 +55,9 @@ const ImageContainer = styled.div`
   background-color: ${({ theme: { allColors } }) => allColors.color4};
   width: 100%;
 
-  ${({ theme: { spacing, mq } }) => css`
+  ${({ theme: { spacing } }) => css`
     margin-bottom: ${spacing[9]}rem;
     position: relative;
-
-    ${mq.xs`
-      height: 12rem;
-    `}
-
-    ${mq.sm`
-      height: 15rem;
-    `}
-
-    ${mq.lg`
-      height: 19rem;
-    `}
   `}
 `;
 
@@ -85,10 +73,18 @@ const StyledImage = styled(ResponsiveImage)`
       height: auto;
     }
 
+    ${mq.xs`
+      height: 12rem;
+    `}
+
+    ${mq.sm`
+      height: 15rem;
+    `}
+
     ${mq.lg`
+      height: 19rem;
       img {
         max-width: 26rem;
-        width: 26rem;
       }
     `}
   `}
@@ -132,7 +128,7 @@ function GeneralCard({
     <Container className={className}>
       {image && (
         <ImageContainer>
-          <StyledImage image={imageProps(image)} width={460} />
+          <StyledImage image={imageProps(image)} />
         </ImageContainer>
       )}
       <ContentContainer>


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[TICKET NUMBER](LINK TO TICKET)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->


## Problems
- Layout is a little off
- `searchParams` isn't working
## Description

- blog index and blog posts have been re added to the page
- Navdata is no longer being fetched in there
- Tags is currently NOT being used in the monorepo; the fetched data is going nowhere. I have commented it out for now
- With regards to moving `blogIndex` out, it makes more sense to have it there because the other catch all route is just pulling in block data, which is what `blogIndex` is doing. So i separated posts and put it in a component within that route. I am not sure if there is a better place for it. By doing it this way we can then easily create a  `Tags` component and import it into `PageTemplate` where the posts are. 



<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
