### PR TITLE
Feat/invalidate cache hook

### DIFF
--- a/apps/web/payload.config.ts
+++ b/apps/web/payload.config.ts
@@ -52,7 +52,7 @@ export default buildConfig({
       connectionString: DATABASE_URL
     },
     push: false,
-    logger: false
+    logger: true
   }),
   editor: lexicalEditor({
     features: () =>

--- a/apps/web/payload.config.ts
+++ b/apps/web/payload.config.ts
@@ -12,7 +12,6 @@ import Homepage from '@mono/web/globals/Home/Homepage.config';
 import Nav from '@mono/web/globals/Layout/Layout.config';
 // import nodeMailer from 'nodemailer';
 import { DEFAULT_LOCALE, LOCALES } from '@mono/web/lib/constants';
-import { WEB_URL } from '@mono/web/lib/constants';
 import { translator } from '@payload-enchants/translator';
 import { googleResolver } from '@payload-enchants/translator/resolvers/google';
 import { postgresAdapter } from '@payloadcms/db-postgres';
@@ -52,7 +51,7 @@ export default buildConfig({
       connectionString: DATABASE_URL
     },
     push: false,
-    logger: true
+    logger: false
   }),
   editor: lexicalEditor({
     features: () =>

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
@@ -50,9 +50,13 @@ export default async function Blog({
 
   const fetchPageData = draft
     ? query
-    : unstable_cache(query, [
-        [locale, draft, 'blog', pageSlug].filter((x) => x).join('/')
-      ]);
+    : unstable_cache(
+        query,
+        [[locale, draft, 'blog', pageSlug].filter((x) => x).join('/')],
+        {
+          tags: [`${pageSlug}`]
+        }
+      );
 
   const [postData] = await fetchPageData(draft, locale, pageSlug);
 

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -39,9 +39,15 @@ export default async function Blog({
 
   const fetchPageData = draft
     ? query
-    : unstable_cache(query, [
-        `${[locale, 'blog'].filter((x) => x).join('/')}?page=${searchParams.page}`
-      ]);
+    : unstable_cache(
+        query,
+        [
+          `${[locale, 'blog'].filter((x) => x).join('/')}?page=${searchParams.page}`
+        ],
+        {
+          tags: ['blogIndex']
+        }
+      );
 
   const indexData = await fetchPageData(draft, locale);
 

--- a/apps/web/src/app/(app)/[locale]/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/[...slug]/page.tsx
@@ -59,7 +59,9 @@ export default async function CatchallPage({
 
   const fetchPageData = draft
     ? query
-    : unstable_cache(query, [[locale, pageSlug].filter((x) => x).join('/')]);
+    : unstable_cache(query, [[locale, pageSlug].filter((x) => x).join('/')], {
+        tags: [`${pageSlug}`]
+      });
 
   const page = await fetchPageData(draft, locale);
 

--- a/apps/web/src/app/(app)/[locale]/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/[...slug]/page.tsx
@@ -29,7 +29,11 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
-async function fetchPageData(draft: boolean | undefined, locale: LanguageLocale, pageSlug: string) {
+async function fetchPageData(
+  draft: boolean | undefined,
+  locale: LanguageLocale,
+  pageSlug: string
+) {
   const cacheKey = [locale, pageSlug].filter((x) => x).join('/');
 
   const query = async (locale: LanguageLocale, pageSlug: string) => {
@@ -45,14 +49,13 @@ async function fetchPageData(draft: boolean | undefined, locale: LanguageLocale,
       limit: 1
     });
     return data?.docs?.[0];
-  }
-
+  };
 
   const executeQuery = draft
     ? query
     : unstable_cache(query, [cacheKey], {
-      tags: [cacheKey]
-    });
+        tags: [cacheKey]
+      });
 
   return executeQuery(locale, pageSlug);
 }

--- a/apps/web/src/app/(app)/[locale]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/page.tsx
@@ -34,7 +34,9 @@ export default async function HomePage({
 
   const fetchPageData = draft
     ? query
-    : unstable_cache(query, [[locale, 'homepage'].filter((x) => x).join('/')]);
+    : unstable_cache(query, [[locale, 'homepage'].filter((x) => x).join('/')], {
+        tags: ['homepage']
+      });
 
   const homepageData = await fetchPageData(draft, locale);
 

--- a/apps/web/src/app/(app)/[locale]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/page.tsx
@@ -18,9 +18,12 @@ export interface RootLayoutProps {
   };
 }
 
-export default async function HomePage({
-  params: { locale = DEFAULT_LOCALE, draft }
-}: RootLayoutProps) {
+async function fetchPageData(
+  draft: boolean | undefined,
+  locale: LanguageLocale
+) {
+  const cacheKey = [locale, 'homepage'].filter((x) => x).join('/');
+
   const query = async (draft: boolean | undefined, locale: LanguageLocale) => {
     const payload = await getPayloadHMR({ config });
     return payload.findGlobal({
@@ -32,12 +35,18 @@ export default async function HomePage({
     });
   };
 
-  const fetchPageData = draft
+  const executeQuery = draft
     ? query
     : unstable_cache(query, [[locale, 'homepage'].filter((x) => x).join('/')], {
-        tags: ['homepage']
+        tags: [cacheKey]
       });
 
+  return executeQuery(draft, locale);
+}
+
+export default async function HomePage({
+  params: { locale = DEFAULT_LOCALE, draft }
+}: RootLayoutProps) {
   const homepageData = await fetchPageData(draft, locale);
 
   return (
@@ -49,35 +58,24 @@ export default async function HomePage({
 }
 
 export async function generateMetadata({
-  params: { locale }
+  params: { draft, locale }
 }: RootLayoutProps) {
   unstable_setRequestLocale(locale);
-  const payload = await getPayloadHMR({ config });
+  const data = await fetchPageData(draft, locale);
 
-  try {
-    const data = await payload.findGlobal({
-      slug: 'homepage',
-      locale,
-      depth: 2,
-      fallbackLocale: DEFAULT_LOCALE
-    });
-
-    if ('error' in data) {
-      return {};
-    }
-
-    const seoImage =
-      'https://ut94wx32cwlqjiry.public.blob.vercel-storage.com/opengraph-IaDqdUZAHTyyH8EfsPaH2oiQFN50MG.jpg';
-
-    return {
-      title: data.pageTitle ?? 'Monorepo',
-      description: 'Default description text',
-      keywords: null,
-      openGraph: {
-        images: [seoImage]
-      }
-    };
-  } catch (_) {
+  if ('error' in data) {
     return {};
   }
+
+  const seoImage =
+    'https://ut94wx32cwlqjiry.public.blob.vercel-storage.com/opengraph-IaDqdUZAHTyyH8EfsPaH2oiQFN50MG.jpg';
+
+  return {
+    title: data.pageTitle ?? 'Monorepo',
+    description: 'Default description text',
+    keywords: null,
+    openGraph: {
+      images: [seoImage]
+    }
+  };
 }

--- a/apps/web/src/collections/Tags.ts
+++ b/apps/web/src/collections/Tags.ts
@@ -1,5 +1,7 @@
 import type { CollectionConfig } from 'payload';
 
+import { invalidateCache } from '../hooks/invalidateCache';
+
 const Tags: CollectionConfig = {
   slug: 'tags',
   access: {
@@ -16,7 +18,10 @@ const Tags: CollectionConfig = {
       localized: true,
       required: true
     }
-  ]
+  ],
+  hooks: {
+    afterChange: [invalidateCache]
+  }
 };
 
 export default Tags;

--- a/apps/web/src/globals/FourOhFour/FourOhFour.config.ts
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.config.ts
@@ -9,8 +9,8 @@ const FourOhFour: GlobalConfig = {
     read: () => true
   },
   fields: [...RichTextFields],
-    hooks: {
-      afterChange: [globalInvalidateCache]
+  hooks: {
+    afterChange: [globalInvalidateCache]
   }
 };
 export default FourOhFour;

--- a/apps/web/src/globals/FourOhFour/FourOhFour.config.ts
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.config.ts
@@ -1,5 +1,6 @@
 import RichTextFields from '@mono/web/payload/fields/RichTextFields';
 import type { GlobalConfig } from 'payload';
+import { globalInvalidateCache } from '../../hooks/globalInvalidateCache';
 
 const FourOhFour: GlobalConfig = {
   slug: 'four-oh-four',
@@ -7,6 +8,9 @@ const FourOhFour: GlobalConfig = {
   access: {
     read: () => true
   },
-  fields: [...RichTextFields]
+  fields: [...RichTextFields],
+    hooks: {
+      afterChange: [globalInvalidateCache]
+  }
 };
 export default FourOhFour;

--- a/apps/web/src/globals/Layout/Layout.config.ts
+++ b/apps/web/src/globals/Layout/Layout.config.ts
@@ -2,6 +2,7 @@ import CTA from '@mono/web/payload/fields/CTA';
 import IconSelect from '@mono/web/payload/fields/IconSelect';
 import Link from '@mono/web/payload/fields/Link';
 import type { ArrayField, GlobalConfig, GroupField } from 'payload';
+import { globalInvalidateCache } from '../../hooks/globalInvalidateCache';
 
 const banner: GroupField = {
   name: 'banner',
@@ -192,7 +193,10 @@ const Nav: GlobalConfig = {
       type: 'group',
       fields: [footerItems]
     }
-  ]
+  ],
+  hooks: {
+    afterChange: [globalInvalidateCache]
+  }
 };
 
 export default Nav;

--- a/apps/web/src/globals/Layout/index.tsx
+++ b/apps/web/src/globals/Layout/index.tsx
@@ -33,7 +33,10 @@ export default async function Layout({
         fallbackLocale: DEFAULT_LOCALE
       });
     },
-    [[locale, draft, 'nav'].filter((x) => x).join('/')]
+    [[locale, draft, 'nav'].filter((x) => x).join('/')],
+    {
+      tags: ['global-nav']
+    }
   );
 
   const navData = await fetchNavData(draft, locale);

--- a/apps/web/src/hooks/globalInvalidateCache.ts
+++ b/apps/web/src/hooks/globalInvalidateCache.ts
@@ -4,8 +4,15 @@ import type { GlobalAfterChangeHook } from 'payload';
 export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
-    if (path) {
-      revalidatePath('/', 'layout');
+
+    // Invalidate the homepage
+    if (path === '/') {
+      revalidatePath('/(app)/[locale]/', 'page');
+    }
+
+    // Invalidate the blog index
+    if (path === 'blog') {
+      revalidatePath(`/(app)/[locale]/(blog)/${path}`, 'page');
     }
   } catch (_err) {
     // no-op

--- a/apps/web/src/hooks/globalInvalidateCache.ts
+++ b/apps/web/src/hooks/globalInvalidateCache.ts
@@ -1,21 +1,11 @@
-import { LOCALES } from '@mono/web/lib/constants';
 import { revalidatePath } from 'next/cache';
 import type { GlobalAfterChangeHook } from 'payload';
-
-function normalizePath(slug: string) {
-  const normalized = `/${slug}`.replace(/\/+/g, '/');
-  return normalized;
-}
 
 export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
-    if (path) {
-      revalidatePath(normalizePath(`/${path}`));
-
-      LOCALES.forEach((locale) => {
-        revalidatePath(normalizePath(`/${locale}/${path}`));
-      });
+    if (path === '/') {
+      revalidatePath('/', 'layout');
     }
   } catch (_err) {
     // no-op

--- a/apps/web/src/hooks/globalInvalidateCache.ts
+++ b/apps/web/src/hooks/globalInvalidateCache.ts
@@ -1,18 +1,21 @@
 import { revalidateTag } from 'next/cache';
 import type { GlobalAfterChangeHook } from 'payload';
 
-export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
+export const globalInvalidateCache: GlobalAfterChangeHook = async ({
+  req,
+  doc
+}) => {
   try {
     const path = doc?.slug;
-
+    const locale = req?.locale;
     // Invalidate the homepage
     if (path === '/') {
-      revalidateTag('homepage');
+      revalidateTag(`${locale}/homepage`);
     }
 
     // Invalidate the blog index
     if (path === 'blog') {
-      revalidateTag('blogIndex');
+      revalidateTag(`${locale}/blogIndex`);
     }
 
     // Invalidate the main layout if the nav or footer is updated

--- a/apps/web/src/hooks/globalInvalidateCache.ts
+++ b/apps/web/src/hooks/globalInvalidateCache.ts
@@ -1,4 +1,4 @@
-import { revalidatePath } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import type { GlobalAfterChangeHook } from 'payload';
 
 export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
@@ -7,17 +7,17 @@ export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
 
     // Invalidate the homepage
     if (path === '/') {
-      revalidatePath('/(app)/[locale]/', 'page');
+      revalidateTag('homepage');
     }
 
     // Invalidate the blog index
     if (path === 'blog') {
-      revalidatePath(`/(app)/[locale]/(blog)/blog`, 'page');
+      revalidateTag('blogIndex');
     }
 
     // Invalidate the main layout if the nav or footer is updated
     if (doc?.header) {
-      revalidatePath('/', 'layout');
+      revalidateTag('global-nav');
     }
   } catch (_err) {
     // no-op

--- a/apps/web/src/hooks/globalInvalidateCache.ts
+++ b/apps/web/src/hooks/globalInvalidateCache.ts
@@ -4,7 +4,7 @@ import type { GlobalAfterChangeHook } from 'payload';
 export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
-    if (path === '/') {
+    if (path) {
       revalidatePath('/', 'layout');
     }
   } catch (_err) {

--- a/apps/web/src/hooks/globalInvalidateCache.ts
+++ b/apps/web/src/hooks/globalInvalidateCache.ts
@@ -12,7 +12,12 @@ export const globalInvalidateCache: GlobalAfterChangeHook = async ({ doc }) => {
 
     // Invalidate the blog index
     if (path === 'blog') {
-      revalidatePath(`/(app)/[locale]/(blog)/${path}`, 'page');
+      revalidatePath(`/(app)/[locale]/(blog)/blog`, 'page');
+    }
+
+    // Invalidate the main layout if the nav or footer is updated
+    if (doc?.header) {
+      revalidatePath('/', 'layout');
     }
   } catch (_err) {
     // no-op

--- a/apps/web/src/hooks/invalidateCache.ts
+++ b/apps/web/src/hooks/invalidateCache.ts
@@ -1,21 +1,11 @@
-import { LOCALES } from '@mono/web/lib/constants';
 import { revalidatePath } from 'next/cache';
 import type { CollectionAfterChangeHook } from 'payload';
-
-function normalizePath(slug: string) {
-  const normalized = `/${slug}`.replace(/\/+/g, '/');
-  return normalized;
-}
 
 export const invalidateCache: CollectionAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
     if (path) {
-      revalidatePath(normalizePath(`/${path}`));
-
-      LOCALES.forEach((locale) => {
-        revalidatePath(normalizePath(`/${locale}/${path}`));
-      });
+      revalidatePath('/', 'layout');
     }
   } catch (_err) {
     // no-op

--- a/apps/web/src/hooks/invalidateCache.ts
+++ b/apps/web/src/hooks/invalidateCache.ts
@@ -1,12 +1,19 @@
 import { revalidatePath } from 'next/cache';
 import type { CollectionAfterChangeHook } from 'payload';
 
+function normalizePath(slug: string) {
+  const normalized = `/${slug}`.replace(/\/+/g, '/');
+  return normalized;
+}
+
 export const invalidateCache: CollectionAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
     if (path) {
-      revalidatePath('/', 'layout');
+      revalidatePath(normalizePath(`/(app)/[locale]/[...slug]`), 'page');
     }
+
+    // TODO after rebase Invalidate the blog posts
   } catch (_err) {
     // no-op
   }

--- a/apps/web/src/hooks/invalidateCache.ts
+++ b/apps/web/src/hooks/invalidateCache.ts
@@ -1,13 +1,16 @@
 import { revalidateTag } from 'next/cache';
 import type { CollectionAfterChangeHook } from 'payload';
 
-export const invalidateCache: CollectionAfterChangeHook = async ({ doc }) => {
+export const invalidateCache: CollectionAfterChangeHook = async ({
+  req,
+  doc
+}) => {
   try {
     const path = doc?.slug;
+    const locale = req?.locale;
+
     // invalidate dynamic block pages / blog detail pages
-    if (path) {
-      revalidateTag(path);
-    }
+    revalidateTag(`${locale}/${path}`);
   } catch (_err) {
     // no-op
   }

--- a/apps/web/src/hooks/invalidateCache.ts
+++ b/apps/web/src/hooks/invalidateCache.ts
@@ -1,24 +1,13 @@
-import { revalidatePath } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import type { CollectionAfterChangeHook } from 'payload';
-
-function normalizePath(slug: string) {
-  const normalized = `/${slug}`.replace(/\/+/g, '/');
-  return normalized;
-}
 
 export const invalidateCache: CollectionAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
-    // invalidate dynamic block pages
+    // invalidate dynamic block pages / blog detail pages
     if (path) {
-      revalidatePath(normalizePath(`/(app)/[locale]/[...slug]`), 'page');
+      revalidateTag(path);
     }
-
-    // invalidate dynamic blog detail pages
-    revalidatePath(
-      normalizePath(`/(app)/[locale]/(blog)/blog/[...slug]`),
-      'page'
-    );
   } catch (_err) {
     // no-op
   }

--- a/apps/web/src/hooks/invalidateCache.ts
+++ b/apps/web/src/hooks/invalidateCache.ts
@@ -9,11 +9,16 @@ function normalizePath(slug: string) {
 export const invalidateCache: CollectionAfterChangeHook = async ({ doc }) => {
   try {
     const path = doc?.slug;
+    // invalidate dynamic block pages
     if (path) {
       revalidatePath(normalizePath(`/(app)/[locale]/[...slug]`), 'page');
     }
 
-    // TODO after rebase Invalidate the blog posts
+    // invalidate dynamic blog detail pages
+    revalidatePath(
+      normalizePath(`/(app)/[locale]/(blog)/blog/[...slug]`),
+      'page'
+    );
   } catch (_err) {
     // no-op
   }


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[TICKET NUMBER](LINK TO TICKET)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page]()
[CMS]()
[Storybook]()

<!-- /links -->

<!-- description -->
## Description
The issue previously was that the hook wasn’t working because we need to explicitly tell next the page path including the route groups. We were only providing the revalidatePath fn with a locale and slug and it couldn’t match the file structure.

- Refactor `InvalidateCacheHook` so that it clears cache on refresh. 
- Add hook to `tags`, `layout` configs
- Verifiy Cache is cleared when the following collections/globals are updated in Payload 
    * homepage
    * general pages
    * blog index page
    * blog post details
    * nav data
    * blog tags



<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
