### PR TITLE
fix(four-oh-four): Missing content & layout.

### DIFF
--- a/apps/web/messages/en-US.json
+++ b/apps/web/messages/en-US.json
@@ -1,5 +1,9 @@
 {
   "Test": {
     "ok": "It's working"
+  },
+  "FourOhFour": {
+    "title": "404 Page",
+    "content": "Page not found"
   }
 }

--- a/apps/web/messages/es-US.json
+++ b/apps/web/messages/es-US.json
@@ -1,5 +1,9 @@
 {
   "Test": {
     "ok": "Está funcionando"
+  },
+  "FourOhFour": {
+    "title": "Página 404",
+    "content": "Página no encontrada"
   }
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
@@ -1,6 +1,6 @@
+import { DEFAULT_THEME_NAME } from '@mono/theme/src/ThemeProvider';
 import UpdatePageTheme from '@mono/web/components/UpdatePageTheme';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
-import { DEFAULT_THEME_NAME } from '@mono/theme/src/ThemeProvider';
 import { redirectApi } from '@mono/web/lib/redirectApi';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -51,8 +51,8 @@ export default async function Blog({
   const fetchPageData = draft
     ? query
     : unstable_cache(query, [
-      [locale, draft, 'blog', pageSlug].filter((x) => x).join('/')
-    ]);
+        [locale, draft, 'blog', pageSlug].filter((x) => x).join('/')
+      ]);
 
   const [postData] = await fetchPageData(draft, locale, pageSlug);
 

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/[...slug]/page.tsx
@@ -1,5 +1,6 @@
-import Layout from '@mono/web/globals/Layout';
+import UpdatePageTheme from '@mono/web/components/UpdatePageTheme';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
+import { DEFAULT_THEME_NAME } from '@mono/theme/src/ThemeProvider';
 import { redirectApi } from '@mono/web/lib/redirectApi';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -50,8 +51,8 @@ export default async function Blog({
   const fetchPageData = draft
     ? query
     : unstable_cache(query, [
-        [locale, draft, 'blog', pageSlug].filter((x) => x).join('/')
-      ]);
+      [locale, draft, 'blog', pageSlug].filter((x) => x).join('/')
+    ]);
 
   const [postData] = await fetchPageData(draft, locale, pageSlug);
 
@@ -68,9 +69,10 @@ export default async function Blog({
   }
 
   return (
-    <Layout locale={locale} draft={draft}>
+    <>
+      <UpdatePageTheme theme={DEFAULT_THEME_NAME} />
       <PageTemplate post={postData.docs[0]} />
-    </Layout>
+    </>
   );
 }
 

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -1,5 +1,5 @@
 import BlocksRenderer from '@mono/web/components/BlocksRenderer';
-import Layout from '@mono/web/globals/Layout';
+import UpdatePageTheme from '@mono/web/components/UpdatePageTheme';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -54,10 +54,11 @@ export default async function Blog({
   const blocks = page.blocks;
 
   return (
-    <Layout theme={page.theme} locale={locale} draft={draft}>
+    <>
+      <UpdatePageTheme theme={page.theme} />
       {blocks && <BlocksRenderer blocks={blocks} />}
       <Posts locale={locale} draft={draft} searchParams={searchParams} />
-    </Layout>
+    </>
   );
 }
 

--- a/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/(blog)/blog/page.tsx
@@ -55,7 +55,6 @@ export default async function Blog({
 
   return (
     <Layout theme={page.theme} locale={locale} draft={draft}>
-      <span>{searchParams.page}</span>
       {blocks && <BlocksRenderer blocks={blocks} />}
       <Posts locale={locale} draft={draft} searchParams={searchParams} />
     </Layout>

--- a/apps/web/src/app/(app)/[locale]/[...slug]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/[...slug]/page.tsx
@@ -1,6 +1,5 @@
 import BlocksRenderer from '@mono/web/components/BlocksRenderer';
-import { RefreshRouteOnSave } from '@mono/web/components/RefreshRouteOnSave';
-import Layout from '@mono/web/globals/Layout';
+import UpdatePageTheme from '@mono/web/components/UpdatePageTheme';
 import { routing } from '@mono/web/i18n/routing';
 import {
   DEFAULT_LOCALE,
@@ -78,10 +77,8 @@ export default async function CatchallPage({
 
   return (
     <>
-      <RefreshRouteOnSave />
-      <Layout theme={page.theme} locale={locale} draft={draft}>
-        <BlocksRenderer blocks={page.blocks ?? []} />
-      </Layout>
+      <UpdatePageTheme theme={page.theme} />
+      <BlocksRenderer blocks={page.blocks ?? []} />
     </>
   );
 }

--- a/apps/web/src/app/(app)/[locale]/draft/layout.tsx
+++ b/apps/web/src/app/(app)/[locale]/draft/layout.tsx
@@ -4,7 +4,7 @@ import { getPayloadHMR } from '@payloadcms/next/utilities';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import type { PayloadRequest } from 'payload';
-import React from 'react';
+import type React from 'react';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;

--- a/apps/web/src/app/(app)/[locale]/layout.tsx
+++ b/apps/web/src/app/(app)/[locale]/layout.tsx
@@ -1,9 +1,9 @@
+import Layout from '@mono/web/globals/Layout';
 import { routing } from '@mono/web/i18n/routing';
 import StyledComponentsRegistry from '@mono/web/lib/StyledComponentRegistry';
 import type { LanguageLocale } from '@mono/web/lib/constants';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, unstable_setRequestLocale } from 'next-intl/server';
-import Layout from '@mono/web/globals/Layout';
 import type React from 'react';
 
 import Providers from './providers';
@@ -23,7 +23,7 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
-async function RootLayout({ children, params: { locale, ...params } }: RootLayoutProps) {
+async function RootLayout({ children, params: { locale } }: RootLayoutProps) {
   unstable_setRequestLocale(locale);
   const messages = await getMessages();
 

--- a/apps/web/src/app/(app)/[locale]/layout.tsx
+++ b/apps/web/src/app/(app)/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import StyledComponentsRegistry from '@mono/web/lib/StyledComponentRegistry';
 import type { LanguageLocale } from '@mono/web/lib/constants';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages, unstable_setRequestLocale } from 'next-intl/server';
+import Layout from '@mono/web/globals/Layout';
 import type React from 'react';
 
 import Providers from './providers';
@@ -22,7 +23,7 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
-async function RootLayout({ children, params: { locale } }: RootLayoutProps) {
+async function RootLayout({ children, params: { locale, ...params } }: RootLayoutProps) {
   unstable_setRequestLocale(locale);
   const messages = await getMessages();
 
@@ -33,7 +34,7 @@ async function RootLayout({ children, params: { locale } }: RootLayoutProps) {
       <StyledComponentsRegistry>
         <Providers>
           <NextIntlClientProvider messages={messages}>
-            {children}
+            <Layout locale={locale}>{children}</Layout>
           </NextIntlClientProvider>
         </Providers>
       </StyledComponentsRegistry>

--- a/apps/web/src/app/(app)/[locale]/not-found.tsx
+++ b/apps/web/src/app/(app)/[locale]/not-found.tsx
@@ -21,11 +21,18 @@ export default async function NotFound() {
       fallbackLocale: DEFAULT_LOCALE
     });
 
-    if ('error' in defaultMarkdownData) {
+    const defaultNavData = await payload.findGlobal({
+      slug: 'nav',
+      locale,
+      depth: 2,
+      fallbackLocale: DEFAULT_LOCALE
+    });
+
+    if ('error' in defaultMarkdownData || 'error' in defaultNavData) {
       return { error: 'Error fetching data' };
     }
 
-    return <FourOhFour markdown={defaultMarkdownData} />;
+    return <FourOhFour markdown={defaultMarkdownData} nav={defaultNavData} />;
   } catch (_) {
     return null;
   }

--- a/apps/web/src/app/(app)/[locale]/not-found.tsx
+++ b/apps/web/src/app/(app)/[locale]/not-found.tsx
@@ -1,32 +1,9 @@
 import FourOhFour from '@mono/web/globals/FourOhFour/FourOhFour.client';
-import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
-import config from '@payload-config';
-import { getPayloadHMR } from '@payloadcms/next/utilities';
-import { cookies } from 'next/headers';
 import React from 'react';
 
-export const dynamic = 'auto';
+export const dynamic = 'force-static';
 export const revalidate = 60;
 
 export default async function NotFound() {
-  const payload = await getPayloadHMR({ config });
-  const locale = (cookies().get('NEXT_LOCALE')?.value ||
-    DEFAULT_LOCALE) as (typeof LOCALES)[number];
-
-  try {
-    const defaultNavData = await payload.findGlobal({
-      slug: 'nav',
-      locale,
-      depth: 2,
-      fallbackLocale: DEFAULT_LOCALE
-    });
-
-    if ('error' in defaultNavData) {
-      return { error: 'Error fetching data' };
-    }
-
-    return <FourOhFour nav={defaultNavData} />;
-  } catch (_) {
-    return null;
-  }
+  return <FourOhFour />;
 }

--- a/apps/web/src/app/(app)/[locale]/not-found.tsx
+++ b/apps/web/src/app/(app)/[locale]/not-found.tsx
@@ -1,4 +1,4 @@
-import NotFoundC from '@mono/web/components/NotFound';
+import FourOhFour from '@mono/web/globals/FourOhFour/FourOhFour.client';
 import Layout from '@mono/web/globals/Layout';
 import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
 import config from '@payload-config';
@@ -6,7 +6,7 @@ import { getPayloadHMR } from '@payloadcms/next/utilities';
 import { cookies } from 'next/headers';
 import React from 'react';
 
-export const dynamic = 'force-static';
+export const dynamic = 'auto';
 export const revalidate = 60;
 
 export default async function NotFound() {
@@ -28,13 +28,7 @@ export default async function NotFound() {
 
     return (
       <Layout locale={locale}>
-        <NotFoundC
-          markdownData={{
-            ...defaultMarkdownData,
-            blockType: 'markdownBlock',
-            id: '42069'
-          }}
-        />
+        <FourOhFour markdown={defaultMarkdownData} />
       </Layout>
     );
   } catch (_) {

--- a/apps/web/src/app/(app)/[locale]/not-found.tsx
+++ b/apps/web/src/app/(app)/[locale]/not-found.tsx
@@ -14,13 +14,6 @@ export default async function NotFound() {
     DEFAULT_LOCALE) as (typeof LOCALES)[number];
 
   try {
-    const defaultMarkdownData = await payload.findGlobal({
-      slug: 'four-oh-four',
-      locale,
-      depth: 1,
-      fallbackLocale: DEFAULT_LOCALE
-    });
-
     const defaultNavData = await payload.findGlobal({
       slug: 'nav',
       locale,
@@ -28,11 +21,11 @@ export default async function NotFound() {
       fallbackLocale: DEFAULT_LOCALE
     });
 
-    if ('error' in defaultMarkdownData || 'error' in defaultNavData) {
+    if ('error' in defaultNavData) {
       return { error: 'Error fetching data' };
     }
 
-    return <FourOhFour markdown={defaultMarkdownData} nav={defaultNavData} />;
+    return <FourOhFour nav={defaultNavData} />;
   } catch (_) {
     return null;
   }

--- a/apps/web/src/app/(app)/[locale]/not-found.tsx
+++ b/apps/web/src/app/(app)/[locale]/not-found.tsx
@@ -1,5 +1,4 @@
 import FourOhFour from '@mono/web/globals/FourOhFour/FourOhFour.client';
-import Layout from '@mono/web/globals/Layout';
 import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -26,11 +25,7 @@ export default async function NotFound() {
       return { error: 'Error fetching data' };
     }
 
-    return (
-      <Layout locale={locale}>
-        <FourOhFour markdown={defaultMarkdownData} />
-      </Layout>
-    );
+    return <FourOhFour markdown={defaultMarkdownData} />;
   } catch (_) {
     return null;
   }

--- a/apps/web/src/app/(app)/[locale]/not-found.tsx
+++ b/apps/web/src/app/(app)/[locale]/not-found.tsx
@@ -1,4 +1,5 @@
 import NotFoundC from '@mono/web/components/NotFound';
+import Layout from '@mono/web/globals/Layout';
 import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -16,7 +17,9 @@ export default async function NotFound() {
   try {
     const defaultMarkdownData = await payload.findGlobal({
       slug: 'four-oh-four',
-      locale
+      locale,
+      depth: 1,
+      fallbackLocale: DEFAULT_LOCALE
     });
 
     if ('error' in defaultMarkdownData) {
@@ -24,13 +27,15 @@ export default async function NotFound() {
     }
 
     return (
-      <NotFoundC
-        markdownData={{
-          ...defaultMarkdownData,
-          blockType: 'markdownBlock',
-          id: '42069'
-        }}
-      />
+      <Layout locale={locale}>
+        <NotFoundC
+          markdownData={{
+            ...defaultMarkdownData,
+            blockType: 'markdownBlock',
+            id: '42069'
+          }}
+        />
+      </Layout>
     );
   } catch (_) {
     return null;

--- a/apps/web/src/app/(app)/[locale]/page.tsx
+++ b/apps/web/src/app/(app)/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import BlocksRenderer from '@mono/web/components/BlocksRenderer';
-import Layout from '@mono/web/globals/Layout';
+import UpdatePageTheme from '@mono/web/components/UpdatePageTheme';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -39,9 +39,10 @@ export default async function HomePage({
   const homepageData = await fetchPageData(draft, locale);
 
   return (
-    <Layout theme={homepageData.theme} locale={locale} draft={draft}>
+    <>
+      <UpdatePageTheme theme={homepageData.theme} />
       <BlocksRenderer blocks={homepageData.blocks ?? []} />
-    </Layout>
+    </>
   );
 }
 

--- a/apps/web/src/components/RefreshRouteOnSave.tsx
+++ b/apps/web/src/components/RefreshRouteOnSave.tsx
@@ -2,7 +2,8 @@
 
 import { RefreshRouteOnSave as PayloadLivePreview } from '@payloadcms/live-preview-react';
 import { useRouter } from 'next/navigation.js';
-import React, { useState, useEffect } from 'react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
 
 export const RefreshRouteOnSave: React.FC = () => {
   const router = useRouter();

--- a/apps/web/src/components/UpdatePageTheme.tsx
+++ b/apps/web/src/components/UpdatePageTheme.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import {
-  usePageThemeContext,
-  type ThemeKey,
   DEFAULT_THEME_NAME,
+  type ThemeKey,
+  usePageThemeContext
 } from '@mono/theme/src/ThemeProvider';
 import { useEffect } from 'react';
 
@@ -12,12 +12,9 @@ interface UpdatePageThemeProps {
 }
 
 export default function UpdatePageTheme({ theme }: UpdatePageThemeProps) {
-  const { currentTheme, setCurrentTheme } = usePageThemeContext();
-
-  console.log('@-->UpdatePageTheme | currentTheme', currentTheme);
+  const { setCurrentTheme } = usePageThemeContext();
 
   useEffect(() => {
-    console.log('@-->UpdatePageTheme.useEffect | currentTheme', currentTheme);
     setCurrentTheme(theme || DEFAULT_THEME_NAME);
   }, [theme, setCurrentTheme]);
 

--- a/apps/web/src/components/UpdatePageTheme.tsx
+++ b/apps/web/src/components/UpdatePageTheme.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import {
+  usePageThemeContext,
+  type ThemeKey,
+  DEFAULT_THEME_NAME,
+} from '@mono/theme/src/ThemeProvider';
+import { useEffect } from 'react';
+
+interface UpdatePageThemeProps {
+  theme?: ThemeKey | null;
+}
+
+export default function UpdatePageTheme({ theme }: UpdatePageThemeProps) {
+  const { currentTheme, setCurrentTheme } = usePageThemeContext();
+
+  console.log('@-->UpdatePageTheme | currentTheme', currentTheme);
+
+  useEffect(() => {
+    console.log('@-->UpdatePageTheme.useEffect | currentTheme', currentTheme);
+    setCurrentTheme(theme || DEFAULT_THEME_NAME);
+  }, [theme, setCurrentTheme]);
+
+  return null;
+}

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -12,12 +12,13 @@ import { usePathname } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 export default function FourOhFour({
-  markdown
-}: { markdown: Partial<FourOhFourTypes> }) {
-  const [markdownData, setMarkdownData] = useState<Partial<FourOhFourTypes>>(
+  markdown,
+  nav
+}: { markdown: FourOhFourTypes; nav: Nav }) {
+  const [markdownData, setMarkdownData] = useState<FourOhFourTypes>(
     markdown ?? {}
   );
-  const [navData, setNavData] = useState<Nav | null>(null);
+  const [navData, setNavData] = useState<Nav>(nav);
   const path = usePathname();
   const locale =
     (path.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -4,42 +4,37 @@ import type {
   FourOhFour as FourOhFourTypes,
   Nav
 } from '@mono/types/payload-types';
-import NotFoundC from '@mono/web/components/NotFound';
 import LayoutClient from '@mono/web/globals/Layout/Layout.client';
 import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
 import { WEB_URL } from '@mono/web/lib/constants';
+import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 
 type FourOhFourProps = {
-  markdown: FourOhFourTypes;
   nav: Nav;
 };
 
-export default function FourOhFour({ markdown, nav }: FourOhFourProps) {
-  const [markdownData, setMarkdownData] = useState<FourOhFourTypes>(
-    markdown ?? null
-  );
+export default function FourOhFour({ nav }: FourOhFourProps) {
   const [navData, setNavData] = useState<Nav>(nav ?? null);
   const path = usePathname();
   const locale =
     (path?.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;
   const webUrl =
     WEB_URL.includes('undefined') || !WEB_URL ? path?.split('/')[0] : WEB_URL;
+  // Using 404 content from translations rather than the cms
+  const t = useTranslations('FourOhFour');
 
   useEffect(() => {
     const fetchMarkdownData = async () => {
       const routeNav = `${webUrl}/api/globals/nav?locale=${locale}`;
-      const route404 = `${webUrl}/api/globals/four-oh-four?locale=${locale}`;
 
       try {
-        const [navResponse, markdownResponse] = await Promise.all([
-          fetch(routeNav).then((res) => res.json()),
-          fetch(route404).then((res) => res.json())
+        const [navResponse] = await Promise.all([
+          fetch(routeNav).then((res) => res.json())
         ]);
 
         setNavData(navResponse);
-        setMarkdownData(markdownResponse);
       } catch (error) {
         console.error(error);
       }
@@ -48,19 +43,23 @@ export default function FourOhFour({ markdown, nav }: FourOhFourProps) {
     fetchMarkdownData();
   }, [locale, webUrl]);
 
-  if (!markdownData || !navData) {
+  if (!navData) {
     return null;
   }
 
+  const styles: React.CSSProperties = {
+    alignContent: 'center',
+    textAlign: 'center',
+    display: 'grid',
+    height: '100%'
+  };
+
   return (
     <LayoutClient {...navData}>
-      <NotFoundC
-        markdownData={{
-          ...markdownData,
-          blockType: 'markdownBlock',
-          id: '42069'
-        }}
-      />
+      <div style={styles}>
+        <h1>{t('title')}</h1>
+        <p>{t('content')}</p>
+      </div>
     </LayoutClient>
   );
 }

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { FourOhFour as FourOhFourTypes } from '@mono/types/payload-types';
+import NotFoundC from '@mono/web/components/NotFound';
+import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
+import { WEB_URL } from '@mono/web/lib/constants';
+import React, { useEffect, useState } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+export default function FourOhFour({
+  markdown
+}: { markdown: Partial<FourOhFourTypes> }) {
+  const [markdownData, setMarkdownData] = useState<Partial<FourOhFourTypes>>(
+    markdown ?? {}
+  );
+  const path = usePathname();
+  const locale =
+    (path.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;
+
+  useEffect(() => {
+    const fetchMarkdownData = async () => {
+      const route = `${WEB_URL}/api/globals/four-oh-four?locale=${locale}`;
+
+      try {
+        const data = fetch(route).then((res) => res.json());
+
+        setMarkdownData(await data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    fetchMarkdownData();
+  }, [locale]);
+
+  if (!markdownData) {
+    return null;
+  }
+
+  return (
+    <NotFoundC
+      markdownData={{
+        ...markdownData,
+        blockType: 'markdownBlock',
+        id: '42069'
+      }}
+    />
+  );
+}

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -9,7 +9,8 @@ import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
 import { WEB_URL } from '@mono/web/lib/constants';
 import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
-import React, { useEffect, useState } from 'react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
 
 type FourOhFourProps = {
   nav: Nav;

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -1,52 +1,9 @@
-'use client';
-
-import type {
-  FourOhFour as FourOhFourTypes,
-  Nav
-} from '@mono/types/payload-types';
-import LayoutClient from '@mono/web/globals/Layout/Layout.client';
-import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
-import { WEB_URL } from '@mono/web/lib/constants';
 import { useTranslations } from 'next-intl';
-import { usePathname } from 'next/navigation';
 import type React from 'react';
-import { useEffect, useState } from 'react';
 
-type FourOhFourProps = {
-  nav: Nav;
-};
-
-export default function FourOhFour({ nav }: FourOhFourProps) {
-  const [navData, setNavData] = useState<Nav>(nav ?? null);
-  const path = usePathname();
-  const locale =
-    (path?.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;
-  const webUrl =
-    WEB_URL.includes('undefined') || !WEB_URL ? path?.split('/')[0] : WEB_URL;
+export default function FourOhFour() {
   // Using 404 content from translations rather than the cms
   const t = useTranslations('FourOhFour');
-
-  useEffect(() => {
-    const fetchMarkdownData = async () => {
-      const routeNav = `${webUrl}/api/globals/nav?locale=${locale}`;
-
-      try {
-        const [navResponse] = await Promise.all([
-          fetch(routeNav).then((res) => res.json())
-        ]);
-
-        setNavData(navResponse);
-      } catch (error) {
-        console.error(error);
-      }
-    };
-
-    fetchMarkdownData();
-  }, [locale, webUrl]);
-
-  if (!navData) {
-    return null;
-  }
 
   const styles: React.CSSProperties = {
     alignContent: 'center',
@@ -56,11 +13,9 @@ export default function FourOhFour({ nav }: FourOhFourProps) {
   };
 
   return (
-    <LayoutClient {...navData}>
-      <div style={styles}>
-        <h1>{t('title')}</h1>
-        <p>{t('content')}</p>
-      </div>
-    </LayoutClient>
+    <div style={styles}>
+      <h1>{t('title')}</h1>
+      <p>{t('content')}</p>
+    </div>
   );
 }

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -1,12 +1,15 @@
 'use client';
 
-import type { FourOhFour as FourOhFourTypes } from '@mono/types/payload-types';
+import type {
+  FourOhFour as FourOhFourTypes,
+  Nav
+} from '@mono/types/payload-types';
 import NotFoundC from '@mono/web/components/NotFound';
+import LayoutClient from '@mono/web/globals/Layout/Layout.client';
 import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
-import { WEB_URL } from '@mono/web/lib/constants';
-import React, { useEffect, useState } from 'react';
-
 import { usePathname } from 'next/navigation';
+// import { WEB_URL } from '@mono/web/lib/constants';
+import React, { useEffect, useState } from 'react';
 
 export default function FourOhFour({
   markdown
@@ -14,17 +17,22 @@ export default function FourOhFour({
   const [markdownData, setMarkdownData] = useState<Partial<FourOhFourTypes>>(
     markdown ?? {}
   );
+  const [navData, setNavData] = useState<Nav | null>(null);
   const path = usePathname();
   const locale =
     (path.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;
+  const webUrl = path.split('/')[0];
 
   useEffect(() => {
     const fetchMarkdownData = async () => {
-      const route = `${WEB_URL}/api/globals/four-oh-four?locale=${locale}`;
+      const routeNav = `${webUrl}/api/globals/nav?locale=${locale}`;
+      const route404 = `${webUrl}/api/globals/four-oh-four?locale=${locale}`;
 
       try {
-        const data = fetch(route).then((res) => res.json());
+        const nav = fetch(routeNav).then((res) => res.json());
+        const data = fetch(route404).then((res) => res.json());
 
+        setNavData(await nav);
         setMarkdownData(await data);
       } catch (error) {
         console.error(error);
@@ -32,19 +40,21 @@ export default function FourOhFour({
     };
 
     fetchMarkdownData();
-  }, [locale]);
+  }, [locale, webUrl]);
 
-  if (!markdownData) {
+  if (!markdownData || !navData) {
     return null;
   }
 
   return (
-    <NotFoundC
-      markdownData={{
-        ...markdownData,
-        blockType: 'markdownBlock',
-        id: '42069'
-      }}
-    />
+    <LayoutClient {...navData}>
+      <NotFoundC
+        markdownData={{
+          ...markdownData,
+          blockType: 'markdownBlock',
+          id: '42069'
+        }}
+      />
+    </LayoutClient>
   );
 }

--- a/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
+++ b/apps/web/src/globals/FourOhFour/FourOhFour.client.tsx
@@ -7,22 +7,25 @@ import type {
 import NotFoundC from '@mono/web/components/NotFound';
 import LayoutClient from '@mono/web/globals/Layout/Layout.client';
 import { DEFAULT_LOCALE, type LOCALES } from '@mono/web/lib/constants';
+import { WEB_URL } from '@mono/web/lib/constants';
 import { usePathname } from 'next/navigation';
-// import { WEB_URL } from '@mono/web/lib/constants';
 import React, { useEffect, useState } from 'react';
 
-export default function FourOhFour({
-  markdown,
-  nav
-}: { markdown: FourOhFourTypes; nav: Nav }) {
+type FourOhFourProps = {
+  markdown: FourOhFourTypes;
+  nav: Nav;
+};
+
+export default function FourOhFour({ markdown, nav }: FourOhFourProps) {
   const [markdownData, setMarkdownData] = useState<FourOhFourTypes>(
-    markdown ?? {}
+    markdown ?? null
   );
-  const [navData, setNavData] = useState<Nav>(nav);
+  const [navData, setNavData] = useState<Nav>(nav ?? null);
   const path = usePathname();
   const locale =
-    (path.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;
-  const webUrl = path.split('/')[0];
+    (path?.split('/')[1] as (typeof LOCALES)[number]) ?? DEFAULT_LOCALE;
+  const webUrl =
+    WEB_URL.includes('undefined') || !WEB_URL ? path?.split('/')[0] : WEB_URL;
 
   useEffect(() => {
     const fetchMarkdownData = async () => {
@@ -30,11 +33,13 @@ export default function FourOhFour({
       const route404 = `${webUrl}/api/globals/four-oh-four?locale=${locale}`;
 
       try {
-        const nav = fetch(routeNav).then((res) => res.json());
-        const data = fetch(route404).then((res) => res.json());
+        const [navResponse, markdownResponse] = await Promise.all([
+          fetch(routeNav).then((res) => res.json()),
+          fetch(route404).then((res) => res.json())
+        ]);
 
-        setNavData(await nav);
-        setMarkdownData(await data);
+        setNavData(navResponse);
+        setMarkdownData(markdownResponse);
       } catch (error) {
         console.error(error);
       }

--- a/apps/web/src/globals/Layout/Layout.client.tsx
+++ b/apps/web/src/globals/Layout/Layout.client.tsx
@@ -6,7 +6,6 @@ import type { Nav as NavT } from '@mono/types/payload-types';
 import Footer from '@mono/ui/components/Footer';
 import Header from '@mono/ui/components/Header';
 import MaybeThemed from '@mono/ui/components/MaybeThemed';
-import { useTranslations } from 'next-intl';
 import React from 'react';
 import type { PropsWithChildren } from 'react';
 
@@ -15,14 +14,10 @@ export interface LayoutType extends PropsWithChildren<NavT> {
 }
 
 function Layout({ children, footer, header, theme }: LayoutType) {
-  const t = useTranslations('Test');
   return (
     <MaybeThemed theme={theme} style={containerStyles}>
       <div style={containerStyles}>
         <Header {...header} />
-        <div>
-          <b>Locale test:</b> {t('ok')}
-        </div>
         <main role="main" style={{ zIndex: 0 }}>
           {children}
         </main>

--- a/apps/web/src/globals/Layout/Layout.client.tsx
+++ b/apps/web/src/globals/Layout/Layout.client.tsx
@@ -1,29 +1,28 @@
 'use client';
 
-import { containerStyles } from '@mono/theme/src/ThemeProvider';
-import type * as themeList from '@mono/theme/src/theme';
+import {
+  containerStyles,
+  type ThemeKey
+} from '@mono/theme/src/ThemeProvider';
 import type { Nav as NavT } from '@mono/types/payload-types';
 import Footer from '@mono/ui/components/Footer';
 import Header from '@mono/ui/components/Header';
-import MaybeThemed from '@mono/ui/components/MaybeThemed';
 import React from 'react';
 import type { PropsWithChildren } from 'react';
 
 export interface LayoutType extends PropsWithChildren<NavT> {
-  theme?: keyof typeof themeList | null;
+  theme?: ThemeKey;
 }
 
-function Layout({ children, footer, header, theme }: LayoutType) {
+function Layout({ children, footer, header }: LayoutType) {
   return (
-    <MaybeThemed theme={theme} style={containerStyles}>
-      <div style={containerStyles}>
-        <Header {...header} />
-        <main role="main" style={{ zIndex: 0 }}>
-          {children}
-        </main>
-        <Footer {...footer?.footerItems} />
-      </div>
-    </MaybeThemed>
+    <div style={containerStyles}>
+      <Header {...header} />
+      <main role="main" style={{ zIndex: 0 }}>
+        {children}
+      </main>
+      <Footer {...footer?.footerItems} />
+    </div>
   );
 }
 

--- a/apps/web/src/globals/Layout/Layout.client.tsx
+++ b/apps/web/src/globals/Layout/Layout.client.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  containerStyles,
-  type ThemeKey
-} from '@mono/theme/src/ThemeProvider';
+import { type ThemeKey, containerStyles } from '@mono/theme/src/ThemeProvider';
 import type { Nav as NavT } from '@mono/types/payload-types';
 import Footer from '@mono/ui/components/Footer';
 import Header from '@mono/ui/components/Header';

--- a/apps/web/src/globals/Layout/index.tsx
+++ b/apps/web/src/globals/Layout/index.tsx
@@ -15,11 +15,7 @@ type LayoutProps = {
   children: React.ReactNode;
 };
 
-export default async function Layout({
-  children,
-  locale,
-  draft
-}: LayoutProps) {
+export default async function Layout({ children, locale, draft }: LayoutProps) {
   const fetchNavData = unstable_cache(
     async (draft: boolean | undefined, locale: LanguageLocale) => {
       const payload = await getPayloadHMR({ config });
@@ -36,9 +32,5 @@ export default async function Layout({
 
   const navData = await fetchNavData(draft, locale);
 
-  return (
-    <LayoutClient {...navData}>
-      {children}
-    </LayoutClient>
-  );
+  return <LayoutClient {...navData}>{children}</LayoutClient>;
 }

--- a/apps/web/src/globals/Layout/index.tsx
+++ b/apps/web/src/globals/Layout/index.tsx
@@ -1,6 +1,5 @@
 'use server';
 
-import type * as themeList from '@mono/theme/src/theme';
 import { DEFAULT_LOCALE, type LanguageLocale } from '@mono/web/lib/constants';
 import config from '@payload-config';
 import { getPayloadHMR } from '@payloadcms/next/utilities';
@@ -11,7 +10,6 @@ import type React from 'react';
 import LayoutClient from './Layout.client';
 
 type LayoutProps = {
-  theme?: keyof typeof themeList | null;
   locale: LanguageLocale;
   draft?: boolean;
   children: React.ReactNode;
@@ -19,7 +17,6 @@ type LayoutProps = {
 
 export default async function Layout({
   children,
-  theme,
   locale,
   draft
 }: LayoutProps) {
@@ -40,7 +37,7 @@ export default async function Layout({
   const navData = await fetchNavData(draft, locale);
 
   return (
-    <LayoutClient theme={theme} {...navData}>
+    <LayoutClient {...navData}>
       {children}
     </LayoutClient>
   );

--- a/apps/web/src/lib/StyledComponentRegistry.tsx
+++ b/apps/web/src/lib/StyledComponentRegistry.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useServerInsertedHTML } from 'next/navigation';
-import React, { useState } from 'react';
+import type React from 'react';
+import { useState } from 'react';
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
 
 export default function StyledComponentsRegistry({

--- a/biome.json
+++ b/biome.json
@@ -249,7 +249,6 @@
   },
   "javascript": {
     "globals": ["describe", "it"],
-    "jsxRuntime": "reactClassic",
     "formatter": {
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",

--- a/packages/theme/src/Reset.tsx
+++ b/packages/theme/src/Reset.tsx
@@ -3,6 +3,10 @@
 import { createGlobalStyle } from 'styled-components';
 
 const GlobalResets = createGlobalStyle`
+  body {
+    transition: background-color 0.3s, color 0.3s;
+  }
+
   button {
     -webkit-appearance: none;
     border-radius: 0;

--- a/packages/theme/src/ThemeProvider.tsx
+++ b/packages/theme/src/ThemeProvider.tsx
@@ -3,11 +3,28 @@
 import { GlobalStyles } from '@refract-ui/sc';
 import type { PropsWithChildren } from 'react';
 import type React from 'react';
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
 
 import GlobalResets from './Reset';
 import * as themeList from './theme';
 
 export type ThemeKey = keyof typeof themeList;
+
+export const DEFAULT_THEME_NAME = 'light' as ThemeKey;
+
+type TPageThemeContext = {
+  currentTheme: ThemeKey;
+  setCurrentTheme: (t: ThemeKey) => void;
+};
+
+const PageThemeContext = createContext<TPageThemeContext>({
+  currentTheme: 'light',
+  setCurrentTheme: () => undefined
+});
+
+export function usePageThemeContext() {
+  return useContext(PageThemeContext);
+}
 
 export const containerStyles = {
   display: 'grid',
@@ -16,17 +33,31 @@ export const containerStyles = {
 };
 
 function ThemeProvider({
-  theme,
   children
 }: PropsWithChildren<{ theme?: ThemeKey }>): React.JSX.Element {
-  const themeKey = theme ?? 'light';
-  const t = themeList[themeKey];
+  const [currentTheme, setCurrentTheme] = useState<ThemeKey>(DEFAULT_THEME_NAME);
+
+  console.log('@-->ThemeProvider | currentTheme', currentTheme);
+
+  const updateCurrentTheme = useCallback((themeName?: ThemeKey | null) => {
+    console.log('@-->ThemeProvider.updateCurrentTheme | currentTheme', currentTheme);
+    const nextTheme = themeName || DEFAULT_THEME_NAME;
+    if (nextTheme !== currentTheme) {
+      setCurrentTheme(nextTheme);
+    }
+  }, [currentTheme]);
+
+  const t = useMemo(() => themeList[currentTheme], [currentTheme]);
 
   return (
-    <GlobalStyles as="body" theme={t} style={containerStyles}>
-      <GlobalResets />
-      {children}
-    </GlobalStyles>
+    <PageThemeContext.Provider
+      value={{ currentTheme, setCurrentTheme: updateCurrentTheme }}
+    >
+      <GlobalStyles as="body" theme={t} style={containerStyles}>
+        <GlobalResets />
+        {children}
+      </GlobalStyles>
+    </PageThemeContext.Provider>
   );
 }
 

--- a/packages/theme/src/ThemeProvider.tsx
+++ b/packages/theme/src/ThemeProvider.tsx
@@ -3,7 +3,13 @@
 import { GlobalStyles } from '@refract-ui/sc';
 import type { PropsWithChildren } from 'react';
 import type React from 'react';
-import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState
+} from 'react';
 
 import GlobalResets from './Reset';
 import * as themeList from './theme';
@@ -35,17 +41,18 @@ export const containerStyles = {
 function ThemeProvider({
   children
 }: PropsWithChildren<{ theme?: ThemeKey }>): React.JSX.Element {
-  const [currentTheme, setCurrentTheme] = useState<ThemeKey>(DEFAULT_THEME_NAME);
+  const [currentTheme, setCurrentTheme] =
+    useState<ThemeKey>(DEFAULT_THEME_NAME);
 
-  console.log('@-->ThemeProvider | currentTheme', currentTheme);
-
-  const updateCurrentTheme = useCallback((themeName?: ThemeKey | null) => {
-    console.log('@-->ThemeProvider.updateCurrentTheme | currentTheme', currentTheme);
-    const nextTheme = themeName || DEFAULT_THEME_NAME;
-    if (nextTheme !== currentTheme) {
-      setCurrentTheme(nextTheme);
-    }
-  }, [currentTheme]);
+  const updateCurrentTheme = useCallback(
+    (themeName?: ThemeKey | null) => {
+      const nextTheme = themeName || DEFAULT_THEME_NAME;
+      if (nextTheme !== currentTheme) {
+        setCurrentTheme(nextTheme);
+      }
+    },
+    [currentTheme]
+  );
 
   const t = useMemo(() => themeList[currentTheme], [currentTheme]);
 

--- a/packages/ui/components/BlogIndex/index.tsx
+++ b/packages/ui/components/BlogIndex/index.tsx
@@ -115,8 +115,8 @@ function BlogIndex({ posts, paginationProps }: BlogIndexType) {
         )}
       </OuterContainer>
       {paginationProps &&
-        paginationProps.total &&
-        paginationProps?.total > 1 ? (
+      paginationProps.total &&
+      paginationProps?.total > 1 ? (
         <Pagination {...paginationProps} blogRef={ref} />
       ) : null}
     </Wrapper>

--- a/packages/ui/components/BlogIndex/index.tsx
+++ b/packages/ui/components/BlogIndex/index.tsx
@@ -57,7 +57,7 @@ export type BlogIndexType = {
   activeFilters?: string[];
 };
 
-function BlogIndex({ posts, page, paginationProps }: BlogIndexType) {
+function BlogIndex({ posts, paginationProps }: BlogIndexType) {
   const ref = useRef<HTMLDivElement>(null);
 
   const defaultImageProps = (thumbnail: Image | number) => {
@@ -77,56 +77,46 @@ function BlogIndex({ posts, page, paginationProps }: BlogIndexType) {
     <Wrapper contentWidth="xl">
       <OuterContainer ref={ref}>
         {posts && (
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={page}
-              initial={{ opacity: 0, x: -50 }}
-              animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: 50 }}
-              transition={{ duration: 0.15 }}
-            >
-              <CardWrapper>
-                {posts &&
-                  posts?.map((post) => {
-                    const { title, date, subTitle, thumbnail, slug, ctas } =
-                      post as Post;
+          <CardWrapper>
+            {posts &&
+              posts?.map((post) => {
+                const { title, date, subTitle, thumbnail, slug, ctas } =
+                  post as Post;
 
-                    const defaultCtas: { cta: CTAType }[] = [
-                      {
-                        cta: {
-                          link: {
-                            label: 'Read More',
-                            type: 'external',
-                            externalHref: `blog/${slug}`,
-                            icon: {
-                              name: 'ArrowRight'
-                            }
-                          }
+                const defaultCtas: { cta: CTAType }[] = [
+                  {
+                    cta: {
+                      link: {
+                        label: 'Read More',
+                        type: 'external',
+                        externalHref: `blog/${slug}`,
+                        icon: {
+                          name: 'ArrowRight'
                         }
                       }
-                    ];
+                    }
+                  }
+                ];
 
-                    return (
-                      <PostWrapper key={`${slug}-${post.id}`}>
-                        <GeneralCard
-                          key={`${slug}-${post.id}`}
-                          image={defaultImageProps(thumbnail)}
-                          headline={title}
-                          date={date}
-                          subHead={subTitle}
-                          ctas={ctas?.length === 0 ? defaultCtas : ctas}
-                        />
-                      </PostWrapper>
-                    );
-                  })}
-              </CardWrapper>
-            </motion.div>
-          </AnimatePresence>
+                return (
+                  <PostWrapper key={`${slug}-${post.id}`}>
+                    <GeneralCard
+                      key={`${slug}-${post.id}`}
+                      image={defaultImageProps(thumbnail)}
+                      headline={title}
+                      date={date}
+                      subHead={subTitle}
+                      ctas={ctas?.length === 0 ? defaultCtas : ctas}
+                    />
+                  </PostWrapper>
+                );
+              })}
+          </CardWrapper>
         )}
       </OuterContainer>
       {paginationProps &&
-      paginationProps.total &&
-      paginationProps?.total > 1 ? (
+        paginationProps.total &&
+        paginationProps?.total > 1 ? (
         <Pagination {...paginationProps} blogRef={ref} />
       ) : null}
     </Wrapper>

--- a/packages/ui/components/GeneralCard/index.tsx
+++ b/packages/ui/components/GeneralCard/index.tsx
@@ -69,8 +69,9 @@ const StyledImage = styled(ResponsiveImage)`
     aspect-ratio: 4/3;
 
     img {
+      width: 100%;
       max-width: 100%;
-      height: auto;
+      aspect-ratio: 4/3;
     }
 
     ${mq.xs`
@@ -128,7 +129,7 @@ function GeneralCard({
     <Container className={className}>
       {image && (
         <ImageContainer>
-          <StyledImage image={imageProps(image)} />
+          <StyledImage image={imageProps(image)} width={330} height={230} />
         </ImageContainer>
       )}
       <ContentContainer>


### PR DESCRIPTION
<!-- gfx pull request template -->
<!-- note: do note remove comments -->

<!-- tickets -->
## Ticket(s)

[TICKET NUMBER](LINK TO TICKET)

<!-- /tickets -->

<!-- links -->
## Links

[Testing Page 404](https://nextjs-vercel-monorepo-web-git-fix-404-missin-f04359-graveflex.vercel.app/es-US/sdfads)

<!-- /links -->

<!-- description -->
## Description

Pulls in the default nav and markdown data, then it fetches the correct locale on client. 

Content needs to be added in the global `four-oh-four`
<img width="875" alt="Screenshot 2024-09-05 at 18 13 42" src="https://github.com/user-attachments/assets/5f4a27af-64b2-4305-a595-8311b9dc0d87">

added layout to `not-found`


<!-- reproduction -->
## Reproduction Steps

<!-- Provide a brief set of steps to verify/view the update. -->
<!-- /reproduction -->

<!-- checks -->
<!-- /checks -->
