### PR TITLE
wip(tests): Add Storybook Test Integration

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -9,38 +9,33 @@ const config: StorybookConfig = {
     '../../../apps/web/**/*.stories.tsx',
     '../../../apps/web/**/**/*.stories.tsx'
   ],
-  addons: [
-    // '@storybook/addon-webpack5-compiler-swc',
-    '@storybook/addon-essentials',
-    '@storybook/addon-links',
-    '@storybook/addon-a11y',
-    {
-      name: '@storybook/addon-styling-webpack',
-      options: {
-        rules: [
-          {
-            test: /\.css$/,
-            sideEffects: true,
-            use: [
-              require.resolve('style-loader'),
-              {
-                loader: require.resolve('css-loader'),
-                options: {
-                  importLoaders: 1
-                }
-              },
-              {
-                loader: require.resolve('postcss-loader'),
-                options: {
-                  implementation: require.resolve('postcss')
-                }
+  addons: [// '@storybook/addon-webpack5-compiler-swc',
+  '@storybook/addon-essentials', '@storybook/addon-links', '@storybook/addon-a11y', {
+    name: '@storybook/addon-styling-webpack',
+    options: {
+      rules: [
+        {
+          test: /\.css$/,
+          sideEffects: true,
+          use: [
+            require.resolve('style-loader'),
+            {
+              loader: require.resolve('css-loader'),
+              options: {
+                importLoaders: 1
               }
-            ]
-          }
-        ]
-      }
+            },
+            {
+              loader: require.resolve('postcss-loader'),
+              options: {
+                implementation: require.resolve('postcss')
+              }
+            }
+          ]
+        }
+      ]
     }
-  ],
+  }, '@storybook/experimental-addon-test'],
   framework: {
     name: '@storybook/nextjs',
     options: {

--- a/apps/web/.storybook/vitest.setup.ts
+++ b/apps/web/.storybook/vitest.setup.ts
@@ -1,0 +1,10 @@
+import { beforeAll } from 'vitest';
+// 👇 If you're using Next.js, import from @storybook/nextjs
+//   If you're using Next.js with Vite, import from @storybook/experimental-nextjs-vite
+import { setProjectAnnotations } from '@storybook/react';
+import * as previewAnnotations from './preview';
+
+const annotations = setProjectAnnotations([previewAnnotations]);
+
+// Run Storybook's beforeAll hook
+beforeAll(annotations.beforeAll);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -157,12 +157,14 @@
     "vite-plugin-svgr": "latest",
     "vite-transform-stub": "latest",
     "vite-tsconfig-paths": "latest",
-    "vitest": "latest",
     "vitest-canvas-mock": "latest",
     "voca": "^1.4.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/nodemailer": "^6.4.15"
+    "@storybook/experimental-addon-test": "^8.5.0",
+    "@types/nodemailer": "^6.4.15",
+    "@vitest/browser": "^3.0.3",
+    "vitest": "3.0.2"
   }
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -26,6 +26,6 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts"
-  ],
+, "vitest.config"  ],
   "exclude": ["node_modules", "**/migrations"]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,34 +1,65 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import { storybookTest } from '@storybook/experimental-addon-test/vitest-plugin';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 import { stubTransform } from 'vite-transform-stub';
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { defineConfig } from 'vitest/config';
 
-export default defineConfig({
-  plugins: [
-    tsconfigPaths(),
-    react(),
-    svgr(),
-    stubTransform(/^.+\.(gif|jpe?g|tiff?|png|webp|bmp)(\?\w+)?$/)
-  ],
-  test: {
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'html', 'cobertura'],
-      include: ['./src/**/*']
-    },
-    globals: true,
-    setupFiles: ['./setup.ts'],
-    environment: 'jsdom',
-    deps: {
-      inline: ['vitest-canvas-mock']
-    },
-    // For this config, check https://github.com/vitest-dev/vitest/issues/740
-    // threads: false,
-    environmentOptions: {
-      jsdom: {
-        resources: 'usable'
+const dirname =
+  typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+export default mergeConfig(
+  defineConfig({
+    plugins: [
+      tsconfigPaths(),
+      react(),
+      svgr(),
+      stubTransform(/^.+\.(gif|jpe?g|tiff?|png|webp|bmp)(\?\w+)?$/)
+    ],
+    test: {
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'html', 'cobertura'],
+        include: ['./src/**/*']
+      },
+      globals: true,
+      setupFiles: ['./setup.ts'],
+      environment: 'jsdom',
+      deps: {
+        inline: ['vitest-canvas-mock']
+      },
+      // For this config, check https://github.com/vitest-dev/vitest/issues/740
+      // threads: false,
+      environmentOptions: {
+        jsdom: {
+          resources: 'usable'
+        }
       }
     }
-  }
-});
+  }),
+  defineConfig({
+    plugins: [
+      storybookTest({
+        // The location of your Storybook config, main.js|ts
+        configDir: path.join(dirname, '.storybook'),
+        // This should match your package.json script to run Storybook
+        // The --ci flag will skip prompts and not open a browser
+        storybookScript: 'yarn storybook --ci',
+      }),
+    ],
+    test: {
+      // Enable browser mode
+      browser: {
+        enabled: true,
+        name: 'chromium',
+        // Make sure to install Playwright
+        provider: 'playwright',
+        headless: true,
+      },
+      setupFiles: ['./.storybook/vitest.setup.ts'],
+    },
+  })
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
         version: 1.1.6(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storybook/addon-a11y':
         specifier: 8.5.0
-        version: 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
+        version: 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
       '@storybook/addon-actions':
         specifier: 8.5.0
         version: 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))
@@ -493,9 +493,6 @@ importers:
       vite-tsconfig-paths:
         specifier: 4.3.2
         version: 4.3.2(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
-      vitest:
-        specifier: 3.0.2
-        version: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
       vitest-canvas-mock:
         specifier: 0.3.3
         version: 0.3.3(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
@@ -631,7 +628,7 @@ importers:
         version: 4.3.2(typescript@5.7.3)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
       vitest:
         specifier: 3.0.2
-        version: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
+        version: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
       vitest-canvas-mock:
         specifier: 0.3.3
         version: 0.3.3(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
@@ -2561,6 +2558,9 @@ packages:
         optional: true
       webpack-plugin-serve:
         optional: true
+
+  '@polka/url@1.0.0-next.28':
+    resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
   '@radix-ui/number@1.1.0':
     resolution: {integrity: sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==}
@@ -9073,6 +9073,10 @@ packages:
     resolution: {integrity: sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==}
     engines: {node: '>=14.16'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
@@ -9800,6 +9804,9 @@ packages:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
     engines: {node: '>=8.0.0'}
     hasBin: true
+
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10623,18 +10630,15 @@ snapshots:
   '@bundled-es-modules/cookie@2.0.1':
     dependencies:
       cookie: 0.7.2
-    optional: true
 
   '@bundled-es-modules/statuses@1.0.1':
     dependencies:
       statuses: 2.0.1
-    optional: true
 
   '@bundled-es-modules/tough-cookie@0.1.6':
     dependencies:
       '@types/tough-cookie': 4.0.5
       tough-cookie: 4.1.4
-    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -11197,7 +11201,6 @@ snapshots:
       '@inquirer/core': 10.1.4(@types/node@22.10.7)
       '@inquirer/type': 3.0.2(@types/node@22.10.7)
       '@types/node': 22.10.7
-    optional: true
 
   '@inquirer/core@10.1.4(@types/node@16.18.11)':
     dependencies:
@@ -11227,7 +11230,6 @@ snapshots:
       yoctocolors-cjs: 2.1.2
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   '@inquirer/core@9.2.1':
     dependencies:
@@ -11324,7 +11326,6 @@ snapshots:
   '@inquirer/type@3.0.2(@types/node@22.10.7)':
     dependencies:
       '@types/node': 22.10.7
-    optional: true
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -11612,7 +11613,6 @@ snapshots:
       is-node-process: 1.2.0
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
-    optional: true
 
   '@neondatabase/api-client@1.11.5':
     dependencies:
@@ -11670,17 +11670,14 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.18.0
 
-  '@open-draft/deferred-promise@2.2.0':
-    optional: true
+  '@open-draft/deferred-promise@2.2.0': {}
 
   '@open-draft/logger@0.3.0':
     dependencies:
       is-node-process: 1.2.0
       outvariant: 1.4.3
-    optional: true
 
-  '@open-draft/until@2.1.0':
-    optional: true
+  '@open-draft/until@2.1.0': {}
 
   '@payload-enchants/translator@1.3.0(@payloadcms/translations@3.18.0)(@payloadcms/ui@3.18.0(@types/react@19.0.0)(monaco-editor@0.52.2)(next@15.1.5(@babel/core@7.26.0)(babel-plugin-react-compiler@19.0.0-beta-decd7b8-20250118)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.77.4))(payload@3.18.0(bufferutil@4.0.9)(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)(utf-8-validate@6.0.5))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3))(payload@3.18.0(bufferutil@4.0.9)(graphql@16.10.0)(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.3)(utf-8-validate@6.0.5))':
     dependencies:
@@ -12006,6 +12003,8 @@ snapshots:
     optionalDependencies:
       type-fest: 4.33.0
       webpack-hot-middleware: 2.26.1
+
+  '@polka/url@1.0.0-next.28': {}
 
   '@radix-ui/number@1.1.0': {}
 
@@ -12916,13 +12915,13 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-  '@storybook/addon-a11y@8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))':
+  '@storybook/addon-a11y@8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))':
     dependencies:
       '@storybook/addon-highlight': 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))
       '@storybook/test': 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))
       axe-core: 4.10.2
       storybook: 8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)
-      vitest-axe: 0.1.0(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
+      vitest-axe: 0.1.0(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
     transitivePeerDependencies:
       - vitest
 
@@ -13678,8 +13677,7 @@ snapshots:
     dependencies:
       '@types/node': 22.10.7
 
-  '@types/cookie@0.6.0':
-    optional: true
+  '@types/cookie@0.6.0': {}
 
   '@types/d3-array@3.2.1': {}
 
@@ -13837,8 +13835,7 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
-  '@types/statuses@2.0.5':
-    optional: true
+  '@types/statuses@2.0.5': {}
 
   '@types/styled-components@5.1.34':
     dependencies:
@@ -13856,8 +13853,7 @@ snapshots:
 
   '@types/tmp@0.2.6': {}
 
-  '@types/tough-cookie@4.0.5':
-    optional: true
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@2.0.11': {}
 
@@ -14074,6 +14070,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/browser@3.0.3(@types/node@22.10.7)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))(vitest@3.0.2)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.0.3(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
+      '@vitest/utils': 3.0.3
+      magic-string: 0.30.17
+      msw: 2.7.0(@types/node@22.10.7)(typescript@5.7.3)
+      sirv: 3.0.0
+      tinyrainbow: 2.0.0
+      vitest: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - vite
+
   '@vitest/coverage-v8@3.0.2(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@16.18.11)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@16.18.11)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -14118,6 +14133,15 @@ snapshots:
   '@vitest/mocker@3.0.2(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))':
     dependencies:
       '@vitest/spy': 3.0.2
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      msw: 2.7.0(@types/node@22.10.7)(typescript@5.7.3)
+      vite: 6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
+
+  '@vitest/mocker@3.0.3(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))':
+    dependencies:
+      '@vitest/spy': 3.0.3
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
@@ -14903,7 +14927,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    optional: true
 
   clone@1.0.4: {}
 
@@ -15003,8 +15026,7 @@ snapshots:
 
   cookie@0.7.1: {}
 
-  cookie@0.7.2:
-    optional: true
+  cookie@0.7.2: {}
 
   core-js-compat@3.40.0:
     dependencies:
@@ -16132,8 +16154,7 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
-  get-caller-file@2.0.5:
-    optional: true
+  get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.3.0: {}
 
@@ -16309,8 +16330,7 @@ snapshots:
       no-case: 2.3.2
       upper-case: 1.1.3
 
-  headers-polyfill@4.0.3:
-    optional: true
+  headers-polyfill@4.0.3: {}
 
   help-me@5.0.0: {}
 
@@ -16620,8 +16640,7 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
 
-  is-node-process@1.2.0:
-    optional: true
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -17461,7 +17480,6 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - '@types/node'
-    optional: true
 
   muggle-string@0.3.1: {}
 
@@ -17469,8 +17487,7 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
-  mute-stream@2.0.0:
-    optional: true
+  mute-stream@2.0.0: {}
 
   nanoid@3.3.8: {}
 
@@ -17718,8 +17735,7 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
-  outvariant@1.4.3:
-    optional: true
+  outvariant@1.4.3: {}
 
   p-finally@2.0.1: {}
 
@@ -18209,7 +18225,6 @@ snapshots:
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
-    optional: true
 
   public-encrypt@4.0.3:
     dependencies:
@@ -18241,8 +18256,7 @@ snapshots:
 
   querystring-es3@0.2.1: {}
 
-  querystringify@2.2.0:
-    optional: true
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -18573,13 +18587,11 @@ snapshots:
       lodash: 4.17.21
       strip-ansi: 6.0.1
 
-  require-directory@2.1.1:
-    optional: true
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
-  requires-port@1.0.0:
-    optional: true
+  requires-port@1.0.0: {}
 
   resolve-dir@1.0.1:
     dependencies:
@@ -18883,6 +18895,8 @@ snapshots:
       mrmime: 2.0.0
       totalist: 3.0.1
 
+  sisteransi@1.0.5: {}
+
   slash@3.0.0: {}
 
   smart-buffer@4.2.0: {}
@@ -19004,8 +19018,7 @@ snapshots:
     optionalDependencies:
       bare-events: 2.5.4
 
-  strict-event-emitter@0.5.1:
-    optional: true
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 
@@ -19308,13 +19321,14 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  totalist@3.0.1: {}
+
   tough-cookie@4.1.4:
     dependencies:
       psl: 1.15.0
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
-    optional: true
 
   tough-cookie@5.1.0:
     dependencies:
@@ -19458,8 +19472,7 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  type-fest@4.33.0:
-    optional: true
+  type-fest@4.33.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -19529,8 +19542,7 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  universalify@0.2.0:
-    optional: true
+  universalify@0.2.0: {}
 
   universalify@2.0.1: {}
 
@@ -19566,7 +19578,6 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
-    optional: true
 
   url@0.11.4:
     dependencies:
@@ -19836,7 +19847,7 @@ snapshots:
       terser: 5.37.0
       tsx: 4.19.2
 
-  vitest-axe@0.1.0(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)):
+  vitest-axe@0.1.0(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)):
     dependencies:
       aria-query: 5.3.2
       axe-core: 4.10.2
@@ -19844,12 +19855,12 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.17.21
       redent: 3.0.0
-      vitest: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
+      vitest: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
 
   vitest-canvas-mock@0.3.3(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)):
     dependencies:
       jest-canvas-mock: 2.5.2
-      vitest: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
+      vitest: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
 
   vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@16.18.11)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@16.18.11)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2):
     dependencies:
@@ -19891,7 +19902,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2):
+  vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2):
     dependencies:
       '@vitest/expect': 3.0.2
       '@vitest/mocker': 3.0.2(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
@@ -20120,8 +20131,7 @@ snapshots:
 
   xtend@4.0.2: {}
 
-  y18n@5.0.8:
-    optional: true
+  y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
@@ -20142,7 +20152,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    optional: true
 
   yauzl-clone@1.0.4:
     dependencies:
@@ -20177,5 +20186,7 @@ snapshots:
       validator: 13.12.0
     optionalDependencies:
       commander: 9.5.0
+
+  zod@3.24.1: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,9 +506,18 @@ importers:
         specifier: ^3.24.1
         version: 3.24.1
     devDependencies:
+      '@storybook/experimental-addon-test':
+        specifier: ^8.5.0
+        version: 8.5.0(@vitest/browser@3.0.3(@types/node@22.10.7)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))(vitest@3.0.2))(@vitest/runner@3.0.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))
       '@types/nodemailer':
         specifier: ^6.4.15
         version: 6.4.17
+      '@vitest/browser':
+        specifier: ^3.0.3
+        version: 3.0.3(@types/node@22.10.7)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))(vitest@3.0.2)
+      vitest:
+        specifier: 3.0.2
+        version: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
 
   packages/tsconfig: {}
 
@@ -3589,6 +3598,21 @@ packages:
   '@storybook/csf@0.1.12':
     resolution: {integrity: sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==}
 
+  '@storybook/experimental-addon-test@8.5.0':
+    resolution: {integrity: sha512-xyXvErBYgAB/7p4GIiRiuFcCSKcOlp0rwqIhMJV1x74GifsIDFfEUehaNuIKlWA0E1M/0xlSZbb/Q89tw2WtFA==}
+    peerDependencies:
+      '@vitest/browser': ^2.1.1 || ^3.0.0
+      '@vitest/runner': ^2.1.1 || ^3.0.0
+      storybook: 8.5.0
+      vitest: 3.0.2
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+      '@vitest/runner':
+        optional: true
+      vitest:
+        optional: true
+
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
 
@@ -3946,6 +3970,12 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
@@ -4299,6 +4329,21 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
+  '@vitest/browser@3.0.3':
+    resolution: {integrity: sha512-Vm6X8gPWotRC/B+CGnBNEOXArISkLmZaN7wmQf/j7WmJJt7tqRvFdOioUzp29HZg2vIGjWq/0pVp6KEiUhEDBA==}
+    peerDependencies:
+      playwright: '*'
+      safaridriver: '*'
+      vitest: 3.0.2
+      webdriverio: '*'
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+
   '@vitest/coverage-v8@3.0.2':
     resolution: {integrity: sha512-U+hZYb0FtgNDb6B3E9piAHzXXIuxuBw2cd6Lvepc9sYYY4KjgiwCBmo3Sird9ZRu3ggLpLBTfw1ZRr77ipiSfw==}
     peerDependencies:
@@ -4316,6 +4361,17 @@ packages:
 
   '@vitest/mocker@3.0.2':
     resolution: {integrity: sha512-Hr09FoBf0jlwwSyzIF4Xw31OntpO3XtZjkccpcBf8FeVW3tpiyKlkeUzxS/txzHqpUCNIX157NaTySxedyZLvA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@3.0.3':
+    resolution: {integrity: sha512-XT2XBc4AN9UdaxJAeIlcSZ0ILi/GzmG5G8XSly4gaiqIvPV3HMTSIDZWJVX6QRJ0PX1m+W8Cy0K9ByXNb/bPIA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -4349,6 +4405,9 @@ packages:
   '@vitest/spy@3.0.2':
     resolution: {integrity: sha512-8mI2iUn+PJFMT44e3ISA1R+K6ALVs47W6eriDTfXe6lFqlflID05MB4+rIFhmDSLBj8iBsZkzBYlgSkinxLzSQ==}
 
+  '@vitest/spy@3.0.3':
+    resolution: {integrity: sha512-7/dgux8ZBbF7lEIKNnEqQlyRaER9nkAL9eTmdKJkDO3hS8p59ATGwKOCUDHcBLKr7h/oi/6hP+7djQk8049T2A==}
+
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
 
@@ -4357,6 +4416,9 @@ packages:
 
   '@vitest/utils@3.0.2':
     resolution: {integrity: sha512-Qu01ZYZlgHvDP02JnMBRpX43nRaZtNpIzw3C1clDXmn8eakgX6iQVGzTQ/NjkIr64WD8ioqOjkaYRVvHQI5qiw==}
+
+  '@vitest/utils@3.0.3':
+    resolution: {integrity: sha512-f+s8CvyzPtMFY1eZKkIHGhPsQgYo5qCm6O8KZoim9qm1/jT64qBgGpO5tHscNH6BzRHM+edLNOP+3vO8+8pE/A==}
 
   '@volar/language-core@1.11.1':
     resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
@@ -7336,6 +7398,10 @@ packages:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
 
+  mrmime@2.0.0:
+    resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
+    engines: {node: '>=10'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -8586,6 +8652,10 @@ packages:
   simple-wcswidth@1.0.1:
     resolution: {integrity: sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==}
 
+  sirv@3.0.0:
+    resolution: {integrity: sha512-BPwJGUeDaDCHihkORDchNyyTvWFhcusy1XMmhEVTQTwGeybFbp8YEmB+njbPnth1FibULBSBVwCQni25XlCUDg==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -9730,9 +9800,6 @@ packages:
     resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
     engines: {node: '>=8.0.0'}
     hasBin: true
-
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -13063,6 +13130,25 @@ snapshots:
     dependencies:
       type-fest: 2.19.0
 
+  '@storybook/experimental-addon-test@8.5.0(@vitest/browser@3.0.3(@types/node@22.10.7)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))(vitest@3.0.2))(@vitest/runner@3.0.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vitest@3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))':
+    dependencies:
+      '@storybook/csf': 0.1.12
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@storybook/instrumenter': 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))
+      '@storybook/test': 8.5.0(storybook@8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))
+      polished: 4.3.1
+      prompts: 2.4.2
+      storybook: 8.5.0(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)
+      ts-dedent: 2.2.0
+    optionalDependencies:
+      '@vitest/browser': 3.0.3(@types/node@22.10.7)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))(vitest@3.0.2)
+      '@vitest/runner': 3.0.2
+      vitest: 3.0.2(@edge-runtime/vm@3.2.0)(@types/node@22.10.7)(@vitest/browser@3.0.3)(jiti@2.4.2)(jsdom@25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5))(lightningcss@1.29.1)(msw@2.7.0(@types/node@22.10.7)(typescript@5.7.3))(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   '@storybook/global@5.0.0': {}
 
   '@storybook/icons@1.3.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
@@ -13494,6 +13580,10 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 
@@ -14069,6 +14159,10 @@ snapshots:
     dependencies:
       tinyspy: 3.0.2
 
+  '@vitest/spy@3.0.3':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/utils@2.0.5':
     dependencies:
       '@vitest/pretty-format': 2.0.5
@@ -14085,6 +14179,12 @@ snapshots:
   '@vitest/utils@3.0.2':
     dependencies:
       '@vitest/pretty-format': 3.0.2
+      loupe: 3.1.2
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.0.3':
+    dependencies:
+      '@vitest/pretty-format': 3.0.3
       loupe: 3.1.2
       tinyrainbow: 2.0.0
 
@@ -17301,6 +17401,8 @@ snapshots:
 
   mri@1.2.0: {}
 
+  mrmime@2.0.0: {}
+
   ms@2.0.0: {}
 
   ms@2.1.1: {}
@@ -18775,7 +18877,11 @@ snapshots:
 
   simple-wcswidth@1.0.1: {}
 
-  sisteransi@1.0.5: {}
+  sirv@3.0.0:
+    dependencies:
+      '@polka/url': 1.0.0-next.28
+      mrmime: 2.0.0
+      totalist: 3.0.1
 
   slash@3.0.0: {}
 
@@ -19810,6 +19916,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
       '@types/node': 22.10.7
+      '@vitest/browser': 3.0.3(@types/node@22.10.7)(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@6.0.5)(vite@6.0.11(@types/node@22.10.7)(jiti@2.4.2)(lightningcss@1.29.1)(sass@1.77.4)(terser@5.37.0)(tsx@4.19.2))(vitest@3.0.2)
       jsdom: 25.0.1(bufferutil@4.0.9)(utf-8-validate@6.0.5)
     transitivePeerDependencies:
       - jiti
@@ -20070,7 +20177,5 @@ snapshots:
       validator: 13.12.0
     optionalDependencies:
       commander: 9.5.0
-
-  zod@3.24.1: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
This WIP PR tests out adding the new Storybook test integration.

I tried the[ Automatic Setup](https://storybook.js.org/docs/writing-tests/test-addon?ref=storybookblog.ghost.io#automatic-setup) in `apps/web` first, but hit this error:

```
│   Storybook Test's automated setup failed due to the following package incompatibilities:                           │
│                                                                                                                     │
│   • The addon can not be used with a custom Webpack configuration.                                                  │
│                                                                                                                     │
│   • You are using @storybook/nextjs without having next installed.                                                  │
│   Please install "next" or use a different Storybook framework integration and try again.
```
Then, I pivoted to doing the [manual installation](https://storybook.js.org/docs/writing-tests/test-addon?ref=storybookblog.ghost.io#manual-setup).

Everything still builds as before but the test integration isn't appearing in the Storybook UI.  My guess is that it's something with how I combined the example `vitest.config.ts` with what we previously had. Or, that there's some config option to opt into the tests that I overlooked.