### PR TITLE
feat(block): Use Dynamic Layout Imports in CtaSectionsBlock

### DIFF
--- a/apps/web/src/blocks/CtaSectionsBlock/index.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/index.tsx
@@ -1,56 +1,52 @@
-// @ts-ignore
 // import Wrapper from '@mono/ui/components/Wrapper';
 import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
 import React from 'react';
 
 import { Button } from '@mono/web/components/ui/Button';
 import { ArrowRight } from 'lucide-react';
+import dynamic from 'next/dynamic';
+import type { ComponentType } from 'react';
 
 export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+const defaultOpts = {
+  suspense: true,
+  ssr: true
+};
+
+// Todo: Convert into a prop:
+const layout: number = 3;
+
+const layoutList: Record<number, ComponentType<CtaSectionsBlockType>> = {
+  1: dynamic(() => import('./layouts/CtaSections1'), {
+    ...defaultOpts
+  }),
+  2: dynamic(() => import('./layouts/CtaSections2'), {
+    ...defaultOpts
+  }),
+  3: dynamic(() => import('./layouts/CtaSections3'), {
+    ...defaultOpts
+  }),
+  4: dynamic(() => import('./layouts/CtaSections4'), {
+    ...defaultOpts
+  }),
+  5: dynamic(() => import('./layouts/CtaSections5'), {
+    ...defaultOpts
+  }),
+  6: dynamic(() => import('./layouts/CtaSections6'), {
+    ...defaultOpts
+  }),
+  7: dynamic(() => import('./layouts/CtaSections7'), {
+    ...defaultOpts
+  })
+};
 
 function CtaSections({
   title = 'Action-Driving headline that creates urgency'
 }: CtaSectionsBlockType) {
-  return (
-    <section
-      className="bg-primary py-16 md:py-24"
-      aria-labelledby="cta-heading"
-    >
-      <div className="container mx-auto px-6">
-        <div className="flex flex-col items-center max-w-xl gap-8 md:gap-10 mx-auto">
-          {/* Section Header */}
-          <div className="flex flex-col items-center gap-4 md:gap-5">
-            {/* Category Tag */}
-            <p className="text-sm md:text-base font-semibold text-primary-foreground text-center opacity-80">
-              CTA section
-            </p>
-            {/* Main Title */}
-            <h2
-              id="cta-heading"
-              className="text-3xl md:text-4xl font-bold text-primary-foreground text-center"
-            >
-              {title}
-            </h2>
-            {/* Section Description */}
-            <p className="text-base md:text-lg text-primary-foreground text-center opacity-80">
-              Add one or two compelling sentences that reinforce your main value
-              proposition and overcome final objections. End with a clear reason
-              to act now. Align this copy with your CTA button text.
-            </p>
-          </div>
+  const Component: ComponentType<CtaSectionsBlockType> = layoutList[layout];
 
-          {/* CTA Button */}
-          <Button
-            className="bg-primary-foreground hover:bg-primary-foreground/80 text-primary"
-            aria-label="Get started with our service"
-          >
-            Get started
-            <ArrowRight />
-          </Button>
-        </div>
-      </div>
-    </section>
-  );
+  return <Component title={title} />;
 }
 
 export default CtaSections;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections1.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections1.tsx
@@ -1,0 +1,55 @@
+// import Wrapper from '@mono/ui/components/Wrapper';
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { Button } from '@mono/web/components/ui/Button';
+import { ArrowRight } from 'lucide-react';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections1({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section
+      className="bg-primary py-16 md:py-24"
+      aria-labelledby="cta-heading"
+    >
+      <div className="container mx-auto px-6">
+        <div className="flex flex-col items-center max-w-xl gap-8 md:gap-10 mx-auto">
+          {/* Section Header */}
+          <div className="flex flex-col items-center gap-4 md:gap-5">
+            {/* Category Tag */}
+            <p className="text-sm md:text-base font-semibold text-primary-foreground text-center opacity-80">
+              CTA section
+            </p>
+            {/* Main Title */}
+            <h2
+              id="cta-heading"
+              className="text-3xl md:text-4xl font-bold text-primary-foreground text-center"
+            >
+              {title}
+            </h2>
+            {/* Section Description */}
+            <p className="text-base md:text-lg text-primary-foreground text-center opacity-80">
+              Add one or two compelling sentences that reinforce your main value
+              proposition and overcome final objections. End with a clear reason
+              to act now. Align this copy with your CTA button text.
+            </p>
+          </div>
+
+          {/* CTA Button */}
+          <Button
+            className="bg-primary-foreground hover:bg-primary-foreground/80 text-primary"
+            aria-label="Get started with our service"
+          >
+            Get started
+            <ArrowRight />
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections1;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections2.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections2.tsx
@@ -1,0 +1,49 @@
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { Button } from '@mono/web/components/ui/Button';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections2({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section
+      className="bg-primary py-16 md:py-24"
+      aria-labelledby="cta-heading"
+    >
+      <div className="container mx-auto px-6">
+        <div className="w-full flex flex-col md:flex-row gap-8 items-center text-center md:text-left justify-between">
+          {/* Main Title */}
+          <h2
+            id="cta-heading"
+            className="text-3xl md:text-4xl font-bold text-primary-foreground max-w-lg"
+          >
+            {title}
+          </h2>
+          {/* CTA Buttons */}
+          <div className="flex flex-col md:flex-row gap-3 align-right">
+            {/* Primary Button */}
+            <Button
+              className="bg-primary-foreground hover:bg-primary-foreground/80 text-primary"
+              aria-label="Get started with our service"
+            >
+              Get started
+            </Button>
+            {/* Secondary Button */}
+            <Button
+              variant="ghost"
+              className="text-primary-foreground hover:text-primary-foreground hover:bg-primary-foreground/10"
+              aria-label="Learn more about our service"
+            >
+              Learn more
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections2;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections3.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections3.tsx
@@ -1,0 +1,67 @@
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { AspectRatio } from '@mono/web/components/ui/AspectRatio';
+import { Button } from '@mono/web/components/ui/Button';
+import { ArrowRight } from 'lucide-react';
+import Image from 'next/image';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections3({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section className="bg-background" aria-labelledby="cta-heading">
+      <div className="max-w-7xl mx-auto px-6 py-16 lg:p-16 lg:rounded-xl bg-primary">
+        <div className="flex flex-col lg:flex-row gap-8 lg:gap-16 items-center lg:max-w-full max-w-xl mx-auto">
+          {/* Left Column - Image */}
+          <div className="flex-1 w-full">
+            <AspectRatio ratio={1}>
+              <Image
+                src="https://ui.shadcn.com/placeholder.svg"
+                alt="CTA section image"
+                fill={true}
+                className="rounded-xl object-cover"
+              />
+            </AspectRatio>
+          </div>
+          {/* Right Column - Content */}
+          <div className="flex flex-col items-center lg:items-start gap-8 md:gap-10 flex-1">
+            {/* Section Header */}
+            <div className="flex flex-col gap-4 md:gap-5 text-center lg:text-left">
+              {/* Category Tag */}
+              <p className="text-sm md:text-base font-semibold text-primary-foreground opacity-80">
+                CTA section
+              </p>
+              {/* Main Title */}
+              <h2
+                id="cta-heading"
+                className="text-3xl md:text-4xl font-bold text-primary-foreground"
+              >
+                {title}
+              </h2>
+              {/* Section Description */}
+              <p className="text-base md:text-lg text-primary-foreground opacity-80">
+                Add one or two compelling sentences that reinforce your main
+                value proposition and overcome final objections. End with a
+                clear reason to act now. Align this copy with your CTA button
+                text.
+              </p>
+            </div>
+            {/* CTA Button */}
+            <Button
+              className="bg-primary-foreground hover:bg-primary-foreground/80 text-primary"
+              aria-label="Get started with our service"
+            >
+              Get started
+              <ArrowRight />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections3;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections4.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections4.tsx
@@ -1,0 +1,76 @@
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { AspectRatio } from '@mono/web/components/ui/AspectRatio';
+import { Button } from '@mono/web/components/ui/Button';
+import { Input } from '@mono/web/components/ui/Input';
+import Image from 'next/image';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections4({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section
+      className="bg-background py-16 lg:py-24"
+      aria-labelledby="cta-heading"
+    >
+      <div className="container px-6 flex flex-col lg:flex-row items-center gap-12 lg:gap-16 mx-auto">
+        {/* Left Column - Content */}
+        <div className="flex flex-col gap-6 lg:gap-8 flex-1">
+          {/* Section Header */}
+          <div className="flex flex-col gap-4 lg:gap-5">
+            {/* Category Tag */}
+            <p className="text-muted-foreground text-sm lg:text-base font-semibold">
+              CTA section
+            </p>
+            {/* Main Title */}
+            <h2
+              id="cta-heading"
+              className="text-foreground text-3xl md:text-4xl font-bold"
+            >
+              {title}
+            </h2>
+            {/* Section Description */}
+            <p className="text-muted-foreground text-base">
+              Add one or two compelling sentences that reinforce your main value
+              proposition and overcome final objections. End with a clear reason
+              to act now. Align this copy with your CTA button text.
+            </p>
+          </div>
+          {/* Email Form */}
+          <form
+            className="flex flex-col md:flex-row gap-3 w-full md:max-w-sm"
+            onSubmit={(e) => e.preventDefault()}
+            aria-label="Email signup form"
+          >
+            <Input
+              placeholder="Email"
+              type="email"
+              required={true}
+              aria-required="true"
+              aria-label="Enter your email"
+            />
+            <Button type="submit" aria-label="Start using our service for free">
+              Start for free
+            </Button>
+          </form>
+        </div>
+        {/* Right Column - Image */}
+        <div className="flex-1 w-full">
+          <AspectRatio ratio={4 / 3}>
+            <Image
+              src="https://ui.shadcn.com/placeholder.svg"
+              alt="CTA section image"
+              fill={true}
+              className="rounded-xl object-cover w-full h-full"
+            />
+          </AspectRatio>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections4;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections5.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections5.tsx
@@ -1,0 +1,72 @@
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { AspectRatio } from '@mono/web/components/ui/AspectRatio';
+import { Button } from '@mono/web/components/ui/Button';
+import { ArrowRight } from 'lucide-react';
+import Image from 'next/image';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections5({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section
+      className="bg-background py-0 lg:py-24"
+      aria-labelledby="cta-heading"
+    >
+      <div className="container mx-auto">
+        <div className="max-w-7xl overflow-hidden bg-primary lg:rounded-xl pt-16 lg:pl-16">
+          <div className="flex flex-col lg:flex-row gap-8 lg:gap-12">
+            {/* Left Column - Content */}
+            <div className="flex flex-col gap-4 px-6 lg:px-0 lg:pb-16 justify-between items-center lg:items-start text-center lg:text-left lg:gap-8 flex-1 lg:max-w-full max-w-xl mx-auto">
+              {/* Section Header */}
+              <div className="flex flex-col gap-4 lg:gap-5">
+                {/* Category Tag */}
+                <p className="text-primary-foreground/80 text-sm lg:text-base font-semibold">
+                  CTA section
+                </p>
+                {/* Main Title */}
+                <h2
+                  id="cta-heading"
+                  className="text-primary-foreground text-3xl md:text-4xl font-bold"
+                >
+                  {title}
+                </h2>
+              </div>
+              {/* CTA Content */}
+              <div className="flex flex-col gap-6 items-center lg:items-start">
+                {/* Section Description */}
+                <p className="text-primary-foreground/80 text-base">
+                  Add one or two compelling sentences that reinforce your main
+                  value proposition and overcome final objections.
+                </p>
+                {/* CTA Button */}
+                <Button
+                  className="bg-primary-foreground text-primary hover:bg-primary-foreground/80"
+                  aria-label="Get started with our service"
+                >
+                  Get started <ArrowRight />
+                </Button>
+              </div>
+            </div>
+            {/* Right Column - Image */}
+            <div className="flex-1 w-full pl-6 lg:pl-0">
+              <AspectRatio ratio={4 / 3}>
+                <Image
+                  src="https://ui.shadcn.com/placeholder.svg"
+                  alt="CTA section image"
+                  fill={true}
+                  className="rounded-tl-lg object-cover w-full h-full"
+                />
+              </AspectRatio>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections5;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections6.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections6.tsx
@@ -1,0 +1,52 @@
+// import Wrapper from '@mono/ui/components/Wrapper';
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { Button } from '@mono/web/components/ui/Button';
+import { ArrowRight } from 'lucide-react';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections6({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section className="bg-background" aria-labelledby="cta-heading">
+      <div className="container mx-auto">
+        <div className="px-6 py-16 md:p-16 bg-primary sm:rounded-xl">
+          <div className="w-full flex flex-col md:flex-row gap-8 items-center text-center md:text-left justify-between">
+            <div className="flex flex-col gap-4 max-w-xl">
+              <h2
+                id="cta-heading"
+                className="text-2xl font-bold text-primary-foreground"
+              >
+                {title}
+              </h2>
+              <p className="text-primary-foreground/80">
+                SSS one or two compelling sentences that reinforce your main
+                value proposition and overcome final objections.
+              </p>
+            </div>
+            <div className="flex flex-col md:flex-row gap-3 align-right">
+              <Button
+                className="bg-primary-foreground hover:bg-primary-foreground/80 text-primary"
+                aria-label="Get started with our service"
+              >
+                Get started
+              </Button>
+              <Button
+                variant="ghost"
+                className="text-primary-foreground hover:text-primary-foreground hover:bg-primary-foreground/10"
+                aria-label="Learn more about our service"
+              >
+                Learn more
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections6;

--- a/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections7.tsx
+++ b/apps/web/src/blocks/CtaSectionsBlock/layouts/CtaSections7.tsx
@@ -1,0 +1,46 @@
+import type { CtaSectionsBlockT as PayloadType } from '@mono/types/payload-types';
+import React from 'react';
+
+import { Button } from '@mono/web/components/ui/Button';
+import { ArrowRight } from 'lucide-react';
+
+export type CtaSectionsBlockType = Omit<PayloadType, 'blockType'>;
+
+function CtaSections7({
+  title = 'Action-Driving headline that creates urgency'
+}: CtaSectionsBlockType) {
+  return (
+    <section className="bg-background" aria-labelledby="cta-heading">
+      <div className="container mx-auto">
+        <div className="px-6 py-16 md:p-16 bg-primary sm:rounded-xl">
+          <div className="w-full flex flex-col gap-8 items-center text-center max-w-xl mx-auto">
+            {/* Section Header */}
+            <div className="flex flex-col gap-5">
+              {/* Category Tag */}
+              <p className="text-primary-foreground/80 text-sm lg:text-base font-semibold">
+                CTA section
+              </p>
+              {/* Main Title */}
+              <h2
+                id="cta-heading"
+                className="text-3xl md:text-4xl font-bold text-primary-foreground"
+              >
+                {title}
+              </h2>
+            </div>
+            {/* CTA Button */}
+            <Button
+              className="bg-primary-foreground hover:bg-primary-foreground/80 text-primary"
+              aria-label="Get started with our service"
+            >
+              Get started
+              <ArrowRight />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default CtaSections7;


### PR DESCRIPTION
This PR uses the same dynamic import logic as our `blocksRenderer` to render the exact layouts provided to us in the Pro Blocks Figma.

I think we are leaning toward making the blocks flexible via classNames but, to Jon's point, I think this is a nice way to make the blocks exactly match the shadcn Pro Blocks Figma from the jump. Then, we can add slight tweaks from there.

Granted, this means we'd need to have some sort of a "Layout Selector" dropdown as a Payload CMS field.  But, if that was paired with explicit documentation, it might not be so bad.