### PR TITLE
feat(component): add richText block for embeds

### DIFF
--- a/apps/web/payload.config.ts
+++ b/apps/web/payload.config.ts
@@ -44,7 +44,7 @@ import {
 import { vercelBlobStorage } from '@payloadcms/storage-vercel-blob';
 import { buildConfig } from 'payload';
 import sharp from 'sharp';
-import CtaSectionsBlock from './src/blocks/CtaSectionsBlock/CtaSectionsBlock.config';
+import { Embed } from './src/components/RichText/Blocks/Embed/config';
 import { EyebrowFeature } from './src/components/RichText/Features/eyebrow/eyebrow.server';
 
 import { fileURLToPath } from 'node:url';
@@ -157,7 +157,11 @@ export default buildConfig({
         BlockquoteFeature(),
         EXPERIMENTAL_TableFeature(),
         FixedToolbarFeature(),
-        EyebrowFeature()
+        EyebrowFeature(),
+        BlocksFeature({
+          blocks: [Embed],
+          inlineBlocks: []
+        })
       ] as FeatureProviderServer<unknown, unknown>[]
   }),
   collections: [Pages, Posts, Authors, Tags, Files, Images, Videos, Users],

--- a/apps/web/src/app/(payload)/admin/importMap.js
+++ b/apps/web/src/app/(payload)/admin/importMap.js
@@ -1,5 +1,6 @@
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
+import { BlocksFeatureClient as BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { EyebrowFeatureClient as EyebrowFeatureClient_d77303697af7ec160cde696ebe36cbe4 } from '@mono/web/components/RichText/Features/eyebrow/eyebrow.client.ts'
 import { FixedToolbarFeatureClient as FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { TableFeatureClient as TableFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
@@ -30,6 +31,7 @@ import { AfterNav as AfterNav_5b7d533c4890c176b0a70fdfa56ed65e } from '@mono/web
 export const importMap = {
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
+  "@payloadcms/richtext-lexical/client#BlocksFeatureClient": BlocksFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@mono/web/components/RichText/Features/eyebrow/eyebrow.client.ts#EyebrowFeatureClient": EyebrowFeatureClient_d77303697af7ec160cde696ebe36cbe4,
   "@payloadcms/richtext-lexical/client#FixedToolbarFeatureClient": FixedToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#TableFeatureClient": TableFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,

--- a/apps/web/src/components/RichText/Blocks/Embed/config.ts
+++ b/apps/web/src/components/RichText/Blocks/Embed/config.ts
@@ -1,0 +1,17 @@
+import type { Block } from 'payload';
+
+export const Embed: Block = {
+  slug: 'embed',
+  fields: [
+    {
+      type: 'text',
+      name: 'embedUrl',
+      required: true
+    },
+    {
+      type: 'text',
+      name: 'embedTitle',
+      required: false
+    }
+  ]
+};

--- a/apps/web/src/components/RichText/RichText.stories.tsx
+++ b/apps/web/src/components/RichText/RichText.stories.tsx
@@ -2,7 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import type { RichTextType } from '.';
 import RichText from '.';
-import richTextMockData, { payloadTypography } from './richTextMockData';
+import richTextMockData, {
+  payloadTypography,
+  embedRichTextMockData
+} from './richTextMockData';
 
 const meta: Meta<RichTextType> = {
   title: 'ui/RichText',
@@ -29,4 +32,8 @@ export const Defaults: Story = {
 
 export const PayloadTypography: Story = {
   args: payloadTypography
+};
+
+export const WithEmbeds: Story = {
+  args: embedRichTextMockData
 };

--- a/apps/web/src/components/RichText/index.tsx
+++ b/apps/web/src/components/RichText/index.tsx
@@ -38,6 +38,18 @@ const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
   ...defaultConverters,
   eyebrow: ({ node }) => {
     return <span className={cn(styles.eyebrow, 'eyebrow')}>{node?.text}</span>;
+  },
+  blocks: {
+    embed: ({ node }: { node: SerializedBlockNode }) => {
+      return (
+        <iframe
+          width="100%"
+          title={node.fields.embedTitle ?? 'Embedded media'}
+          allow="autoplay"
+          src={node.fields.embedUrl}
+        ></iframe>
+      );
+    }
   }
 });
 

--- a/apps/web/src/components/RichText/index.tsx
+++ b/apps/web/src/components/RichText/index.tsx
@@ -47,6 +47,7 @@ const jsxConverters: JSXConvertersFunction<DefaultNodeTypes> = ({
           title={node.fields.embedTitle ?? 'Embedded media'}
           allow="autoplay"
           src={node.fields.embedUrl}
+          className="embed embed-block"
         ></iframe>
       );
     }

--- a/apps/web/src/components/RichText/richTextMockData.ts
+++ b/apps/web/src/components/RichText/richTextMockData.ts
@@ -1977,4 +1977,169 @@ const richTextMockData: RichTextType = {
   }
 };
 
+export const embedRichTextMockData: RichTextType = {
+  data: {
+    root: {
+      type: 'root',
+      format: '',
+      indent: 0,
+      version: 1,
+      children: [
+        {
+          type: 'paragraph',
+          format: 'center',
+          indent: 0,
+          version: 1,
+          children: [
+            {
+              mode: 'normal',
+              text: 'Eyebrow Text',
+              type: 'eyebrow',
+              style: '',
+              detail: 0,
+              format: 0,
+              version: 1
+            }
+          ],
+          direction: 'ltr',
+          textStyle: '',
+          textFormat: 0
+        },
+        {
+          tag: 'h2',
+          type: 'heading',
+          format: 'center',
+          indent: 0,
+          version: 1,
+          children: [
+            {
+              mode: 'normal',
+              text: 'Action-driving headline that creates urgency',
+              type: 'text',
+              style: '',
+              detail: 0,
+              format: 0,
+              version: 1
+            }
+          ],
+          direction: 'ltr'
+        },
+        {
+          type: 'paragraph',
+          format: 'center',
+          indent: 0,
+          version: 1,
+          children: [
+            {
+              mode: 'normal',
+              text: 'Add one or two compelling sentences that reinforce your main value proposition and overcome final objections.',
+              type: 'text',
+              style: '',
+              detail: 0,
+              format: 0,
+              version: 1
+            }
+          ],
+          direction: 'ltr',
+          textStyle: '',
+          textFormat: 0
+        },
+        {
+          type: 'paragraph',
+          format: 'center',
+          indent: 0,
+          version: 1,
+          children: [],
+          direction: null,
+          textStyle: '',
+          textFormat: 0
+        },
+        {
+          type: 'block',
+          fields: {
+            id: '67aa7072868c0f54105528eb',
+            embedUrl:
+              'https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/1079719264&color=0095c8&show_artwork=false',
+            blockName: 'Soundcloud',
+            blockType: 'embed',
+            embedTitle: '643 Pandemic Road Trip'
+          },
+          format: '',
+          version: 2
+        },
+        {
+          type: 'paragraph',
+          format: '',
+          indent: 0,
+          version: 1,
+          children: [],
+          direction: null,
+          textStyle: '',
+          textFormat: 0
+        },
+        {
+          type: 'block',
+          fields: {
+            id: '67aa709a868c0f54105528ec',
+            embedUrl:
+              'https://embed.podcasts.apple.com/us/podcast/don-george-wanderlust-in-the-time-of-coronavirus/id327760888?i=1000512757281',
+            blockName: 'Podcasts',
+            blockType: 'embed',
+            embedTitle: 'Wanderlust in the Time of Coronavirus'
+          },
+          format: '',
+          version: 2
+        },
+        {
+          type: 'paragraph',
+          format: '',
+          indent: 0,
+          version: 1,
+          children: [],
+          direction: null,
+          textStyle: '',
+          textFormat: 0
+        },
+        {
+          type: 'block',
+          fields: {
+            id: '67aa70b2868c0f54105528ed',
+            embedUrl:
+              '//html5-player.libsyn.com/embed/episode/id/19179794/height/90/theme/custom/thumbnail/yes/direction/backward/render-playlist/no/custom-color/87A93A/"   // src="https://embed.podcasts.apple.com/us/podcast/don-george-wanderlust-in-the-time-of-coronavirus/id327760888?i=1000512757281',
+            blockName: 'LibSyn',
+            blockType: 'embed',
+            embedTitle: 'Confessions of a Confirmed Traveler'
+          },
+          format: '',
+          version: 2
+        },
+        {
+          type: 'paragraph',
+          format: '',
+          indent: 0,
+          version: 1,
+          children: [],
+          direction: null,
+          textStyle: '',
+          textFormat: 0
+        },
+        {
+          type: 'block',
+          fields: {
+            id: '67aa7126868c0f54105528ee',
+            embedUrl:
+              'https://www.youtube-nocookie.com/embed/nYlQaxfMPMY?modestbranding=1&rel=0',
+            blockName: 'Video',
+            blockType: 'embed',
+            embedTitle: 'Navigating Traffic on a Cotonou, Benin Drive'
+          },
+          format: '',
+          version: 2
+        }
+      ],
+      direction: 'ltr'
+    }
+  }
+};
+
 export default richTextMockData;


### PR DESCRIPTION
Add Custom Block to richText editor to handle embeds. The block just takes a url and stuffs it into an `iframe`.


[Storybook Story for RichText w/ a few Embeds](https://graveflex-web-git-feat-embed-custom-block-gex-69-graveflex.vercel.app/stories/index.html?path=/story/ui-richtext--with-embeds)

View of CMS w/ embeds:
<img width="350" alt="cms-richtext-with-embeds" src="https://github.com/user-attachments/assets/3d0f8e9a-8cb5-453e-9957-86e9669258c4" />
